### PR TITLE
fix: broken image reference in loading page (LES-74)

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -17,12 +17,14 @@ Create a Linear issue and branch ready to start work on a new task.
    - Description: problem statement, proposed solution, Definition of Done checklist
    - Assign to `me`
 
-3. **Create a git branch** from `develop`:
+3. **Create a git branch** from an up-to-date `develop` — always pull before branching:
    ```
-   git checkout develop && git pull origin develop
+   git checkout develop
+   git pull origin develop
    git checkout -b <type>/les-<number>-<short-slug>
    ```
    Slug: lowercase, hyphens, max 5 words derived from the title.
+   If there are uncommitted changes on the current branch, stash them first (`git stash`).
 
 4. **Confirm** to the user:
    - Linear issue URL and number

--- a/src/app/__tests__/loading.test.tsx
+++ b/src/app/__tests__/loading.test.tsx
@@ -1,0 +1,19 @@
+import Loading from '@/app/loading'
+import { images } from '@/lib/images'
+import { render } from '@testing-library/react'
+import Image from 'next/image'
+
+describe('Loading', () => {
+  it('renders the loading container', () => {
+    const { container } = render(<Loading />)
+    expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('uses the logo from images (not a broken /logo.png path)', () => {
+    render(<Loading />)
+    expect(vi.mocked(Image)).toHaveBeenCalledWith(
+      expect.objectContaining({ src: images.logo }),
+      undefined
+    )
+  })
+})

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,10 +1,11 @@
+import { images } from '@/lib/images'
 import Image from 'next/image'
 
 export default function Loading() {
   return (
     <div className="flex h-screen items-center justify-center">
       <Image
-        src="/logo.png"
+        src={images.logo}
         alt="Loading"
         width={100}
         height={100}


### PR DESCRIPTION
## Summary

- Replace hardcoded `src="/logo.png"` (missing file) with `images.logo` from `@/lib/images`
- Add `src/app/__tests__/loading.test.tsx` with 100% coverage on `loading.tsx`

## Test plan

- [x] `bunx vitest run --coverage src/app/__tests__/loading.test.tsx` → 2 tests pass, `loading.tsx` at 100% stmts/branches/funcs/lines
- [ ] Verify loading spinner shows the logo correctly in the browser

Linear: https://linear.app/lesteban/issue/LES-74/fix-broken-image-reference-in-loading-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)