### PR TITLE
fix: correct double-h typo in Parapente video URL (LES-73)

### DIFF
--- a/src/lib/__tests__/data.test.ts
+++ b/src/lib/__tests__/data.test.ts
@@ -28,6 +28,18 @@ describe('Data Constants', () => {
         }
       })
     })
+
+    it('all tour image/video URLs start with https://', () => {
+      TOURS.forEach((tour) => {
+        expect(tour.image).toMatch(/^https:\/\//)
+        tour.images?.forEach(({ url }) => {
+          expect(url).toMatch(/^https:\/\//)
+        })
+        tour.activities?.forEach((activity) => {
+          expect(activity.image).toMatch(/^https:\/\//)
+        })
+      })
+    })
   })
 
   describe('HEADER_LINKS', () => {

--- a/src/lib/data.tsx
+++ b/src/lib/data.tsx
@@ -423,7 +423,7 @@ export const TOURS = [
       },
       {
         type: 'video',
-        url: 'hhttps://res.cloudinary.com/lesteban/video/upload/v1749943359/roadmapcol/parapente/parapente-3_rq6vsk.mov',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/v1749943359/roadmapcol/parapente/parapente-3_rq6vsk.mov',
         alt: 'parapente',
       },
     ],


### PR DESCRIPTION
## Summary

- Remove extra `h` from `hhttps://` in the Parapente tour video URL in `src/lib/data.tsx`
- Add URL validation test to `data.test.ts`: asserts all tour image/video URLs start with `https://`

## Test plan

- [x] `bunx vitest run --coverage src/lib/__tests__/data.test.ts` → 6 tests pass, `data.tsx` at 100% coverage
- [ ] Visit the Paragliding tour page and verify the video loads correctly

Linear: https://linear.app/lesteban/issue/LES-73/fix-broken-video-url-in-parapente-tour-double-h

🤖 Generated with [Claude Code](https://claude.com/claude-code)