### PR TITLE
feat: Generate sitemap.xml and robots.txt (LES-80)

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,8 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { allow: '/', userAgent: '*' },
+    sitemap: 'https://roadmapcol.com/sitemap.xml',
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,25 @@
+import { TOURS } from '@/lib/data'
+import { MetadataRoute } from 'next'
+
+const BASE_URL = 'https://roadmapcol.com'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { changeFrequency: 'weekly', priority: 1, url: BASE_URL },
+    { changeFrequency: 'weekly', priority: 0.9, url: `${BASE_URL}/tours` },
+    {
+      changeFrequency: 'monthly',
+      priority: 0.7,
+      url: `${BASE_URL}/personalize`,
+    },
+  ]
+
+  const uniqueTourHrefs = [...new Set(TOURS.map((tour) => tour.href))]
+  const tourRoutes: MetadataRoute.Sitemap = uniqueTourHrefs.map((href) => ({
+    changeFrequency: 'monthly',
+    priority: 0.8,
+    url: `${BASE_URL}${href}`,
+  }))
+
+  return [...staticRoutes, ...tourRoutes]
+}


### PR DESCRIPTION
## What and why
Search engines had no explicit crawl instructions — no \`sitemap.xml\` or \`robots.txt\` existed. This adds both using Next.js's built-in file conventions so crawlers can discover and index all tour pages faster and more completely.

## Changes
- Add \`src/app/sitemap.ts\`: generates a sitemap with static routes (\`/\`, \`/tours\`, \`/personalize\`) and one entry per unique tour URL derived from \`TOURS\` in \`src/lib/data.tsx\`
- Add \`src/app/robots.ts\`: allows all crawlers and points to \`https://roadmapcol.com/sitemap.xml\`

## Type of change
- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Chore / refactor (no behaviour change)
- [ ] Breaking change (existing functionality is affected)

## Test plan
- [ ] Deploy preview: visit \`/sitemap.xml\` — all 11 URLs present (3 static + 8 tours)
- [ ] Visit \`/robots.txt\` — shows \`Allow: /\` and sitemap URL
- [ ] Run \`bun test\` — all tests pass (pre-existing failures unrelated to this PR)
- [ ] Run \`bun run type-check\` — no type errors

## Notes for reviewer
Pre-existing test failures (20 failing) are unrelated to this PR and exist on \`develop\` as well. Both files are pure server-side Next.js route handlers with no client-side impact.

---
Linear: https://linear.app/lesteban/issue/LES-80/generate-sitemapxml-and-robotstxt