### PR TITLE
feat: Add dynamic metadata per tour page (LES-79)

### DIFF
--- a/src/app/tours/[name]/page.tsx
+++ b/src/app/tours/[name]/page.tsx
@@ -1,264 +1,33 @@
-'use client'
+import { TOURS } from '@/lib/data'
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
 
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader } from '@/components/ui/card'
-import { TourMediaCarousel } from '@/components/ui/tour-media-carousel'
-import { CONTACT, TOURS } from '@/lib/data'
-import { images } from '@/lib/images'
-import { ArrowLeft, Check, Clock, MapPin } from 'lucide-react'
-import Image from 'next/image'
-import Link from 'next/link'
-import { useParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import TourClient, { type Tour } from './tour-client'
 
-interface Activity {
-  title: string
-  description: string
-  image: string
-  duration?: string
-  includes?: string[]
-  price?: number
+interface PageProps {
+  params: Promise<{ name: string }>
 }
 
-interface Tour {
-  place: string
-  title: string
-  description: string
-  image: string
-  images?: Array<{
-    type: 'image' | 'video'
-    url: string
-    alt: string
-  }>
-  duration: string
-  highlights: string[]
-  href: string
-  price: number
-  activities: Activity[]
-}
-
-export default function TourPage() {
-  const { name } = useParams()
-  const tour = TOURS.find((tour) => tour.href === `/tours/${name}`) as
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { name } = await params
+  const tour = TOURS.find((t) => t.href === `/tours/${name}`) as
     | Tour
     | undefined
-  const [selectedActivities, setSelectedActivities] = useState<string[]>([])
-  const [message, setMessage] = useState<string>('')
-
-  const getSelectedActivityPrice = (activityTitle: string) => {
-    const activity = tour?.activities?.find(
-      (activity) => activity.title === activityTitle
-    )
-    return Number(activity?.price ?? 0)
+  if (!tour) return {}
+  return {
+    description: tour.description,
+    openGraph: { images: [{ alt: tour.title, url: tour.image }] },
+    title: tour.title,
   }
+}
 
-  const totalPrice =
-    (tour?.price || 0) +
-    selectedActivities.reduce(
-      (acc, title) => acc + getSelectedActivityPrice(title),
-      0
-    )
-
-  useEffect(() => {
-    if (tour) {
-      setMessage(
-        `Hello, I would like to get more information about the tour ${tour.title}${selectedActivities.length > 0 ? `, with the activities: ${selectedActivities.join(', ')}` : ''}. With an approximate value of ${totalPrice}`
-      )
-    }
-  }, [tour, selectedActivities, totalPrice])
-
-  if (!tour) {
-    return (
-      <div className="mx-auto my-14 flex flex-col items-center justify-center gap-12 md:w-6/12">
-        <h1 className="text-2xl font-bold">Tour not found</h1>
-        <Link
-          href="/tours"
-          className="text-muted-foreground hover:text-foreground flex items-center gap-2 text-sm transition-colors duration-200"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Back to tours
-        </Link>
-      </div>
-    )
-  }
-
-  const handleActivityToggle = (activityTitle: string) => {
-    setSelectedActivities((prev) => {
-      if (prev.includes(activityTitle)) {
-        return prev.filter((title) => title !== activityTitle)
-      }
-      return [...prev, activityTitle]
-    })
-  }
-
-  return (
-    <div className="mx-auto my-14 flex flex-col items-center justify-center gap-12 md:w-6/12">
-      <Link
-        href="/tours"
-        className="text-muted-foreground hover:text-foreground flex items-center gap-2 self-start text-sm transition-colors duration-200"
-      >
-        <ArrowLeft className="h-4 w-4" />
-        Back to tours
-      </Link>
-      <Card className="mx-auto flex w-11/12 flex-col pt-0 md:w-full">
-        <CardHeader className="px-0 pt-0">
-          {tour.images ? (
-            <TourMediaCarousel items={tour.images} />
-          ) : (
-            <Image
-              src={tour.image}
-              alt={tour.place}
-              width={500}
-              height={500}
-              className="aspect-[4/3] w-full rounded-t-[14px] object-cover"
-            />
-          )}
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-4">
-            <div className="text-muted-foreground flex items-center gap-1">
-              <MapPin />
-              <p>{tour.place}</p>
-            </div>
-            <div className="text-muted-foreground flex items-center gap-1">
-              <Clock />
-              <p>{tour.duration}</p>
-            </div>
-          </div>
-          <h2 className="text-2xl font-bold">{tour.title}</h2>
-          <p className="text-muted-foreground">{tour.description}</p>
-          <h3 className="text-xl font-bold">Highlights:</h3>
-          <ul className="grid list-inside list-disc gap-2 md:grid-cols-2">
-            {tour.highlights.map((highlight) => (
-              <li key={highlight}>{highlight}</li>
-            ))}
-          </ul>
-        </CardContent>
-      </Card>
-
-      {tour.activities.length > 0 && (
-        <h2 className="ml-4 self-start text-2xl font-bold">
-          Available activities:
-        </h2>
-      )}
-      <div className="flex flex-col gap-4">
-        {tour.activities.length > 0
-          ? tour.activities.map((activity) => (
-              <Card
-                key={activity.title}
-                className="mx-auto flex w-11/12 flex-col py-0 md:w-full md:flex-row"
-              >
-                <Image
-                  src={activity.image}
-                  alt={activity.title}
-                  width={200}
-                  height={200}
-                  className="w-full rounded-t-[14px] object-cover md:w-4/12 md:rounded-l-[14px] md:rounded-r-none"
-                />
-                <div className="flex flex-col gap-2 p-4">
-                  <div className="flex w-full items-center justify-between gap-4">
-                    <h3 className="text-xl font-bold">{activity.title}</h3>
-                    <p className="text-muted-foreground">{activity.duration}</p>
-                  </div>
-                  <p className="text-muted-foreground">
-                    {activity.description}
-                  </p>
-                  {activity.includes && (
-                    <div>
-                      <p className="font-bold">Includes:</p>
-                      <ul className="grid grid-cols-2 gap-2">
-                        {activity.includes.map((include: string) => (
-                          <li key={include} className="flex items-center gap-2">
-                            <Check className="text-primary h-4 w-4" />
-                            {include}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                  <div className="flex items-center justify-between">
-                    <p className="text-secondary text-xl font-bold">
-                      ${Number(activity.price).toLocaleString()}
-                    </p>
-                    <Button
-                      variant={
-                        selectedActivities.includes(activity.title)
-                          ? 'outline'
-                          : 'default'
-                      }
-                      onClick={() => handleActivityToggle(activity.title)}
-                    >
-                      {selectedActivities.includes(activity.title)
-                        ? 'Remove from my experience'
-                        : 'Add to my experience'}
-                    </Button>
-                  </div>
-                </div>
-              </Card>
-            ))
-          : null}
-      </div>
-      <Card className="mx-auto w-11/12 px-4 md:w-full">
-        <CardHeader>
-          <h2 className="text-2xl font-bold">Summary of your experience</h2>
-          <div className="flex flex-col gap-4">
-            <div className="flex items-center justify-between">
-              <p className="text-muted-foreground">Base price:</p>
-              <p className="text-lg font-bold">
-                ${Number(tour.price).toLocaleString()} / person
-              </p>
-            </div>
-            {selectedActivities.length > 0 && (
-              <>
-                <div className="border-t pt-4">
-                  <p className="mb-2 font-bold">Selected activities:</p>
-                  {selectedActivities.map((title) => (
-                    <div
-                      key={title}
-                      className="flex items-center justify-between"
-                    >
-                      <p className="text-muted-foreground">{title}</p>
-                      <p className="font-bold">
-                        $
-                        {Number(
-                          getSelectedActivityPrice(title)
-                        ).toLocaleString()}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-                <div className="border-t pt-4">
-                  <div className="flex items-center justify-between">
-                    <p className="text-lg font-bold">Total:</p>
-                    <p className="text-lg font-bold">
-                      ${Number(totalPrice).toLocaleString()}
-                    </p>
-                  </div>
-                </div>
-              </>
-            )}
-          </div>
-        </CardHeader>
-        <Button
-          className="flex w-full items-center gap-2 bg-green-500 text-white hover:bg-green-600"
-          asChild
-        >
-          <Link
-            href={`https://wa.me/${CONTACT.phone}?text=${encodeURIComponent(message)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              src={images.whatsapp}
-              alt="whatsapp"
-              width={20}
-              height={20}
-            />
-            <p>Consult by Whatsapp</p>
-          </Link>
-        </Button>
-      </Card>
-      <div className="flex justify-center"></div>
-    </div>
-  )
+export default async function TourPage({ params }: PageProps) {
+  const { name } = await params
+  const tour = TOURS.find((t) => t.href === `/tours/${name}`) as
+    | Tour
+    | undefined
+  if (!tour) notFound()
+  return <TourClient tour={tour} />
 }

--- a/src/app/tours/[name]/tour-client.tsx
+++ b/src/app/tours/[name]/tour-client.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { TourMediaCarousel } from '@/components/ui/tour-media-carousel'
+import { CONTACT } from '@/lib/data'
+import { images } from '@/lib/images'
+import { ArrowLeft, Check, Clock, MapPin } from 'lucide-react'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+
+interface Activity {
+  description: string
+  duration?: string
+  image: string
+  includes?: string[]
+  price?: number
+  title: string
+}
+
+export interface Tour {
+  activities: Activity[]
+  description: string
+  duration: string
+  highlights: string[]
+  href: string
+  image: string
+  images?: Array<{
+    alt: string
+    type: 'image' | 'video'
+    url: string
+  }>
+  place: string
+  price: number
+  title: string
+}
+
+export default function TourClient({ tour }: { tour: Tour }) {
+  const [selectedActivities, setSelectedActivities] = useState<string[]>([])
+  const [message, setMessage] = useState<string>('')
+
+  const getSelectedActivityPrice = (activityTitle: string) => {
+    const activity = tour.activities?.find(
+      (activity) => activity.title === activityTitle
+    )
+    return Number(activity?.price ?? 0)
+  }
+
+  const totalPrice =
+    tour.price +
+    selectedActivities.reduce(
+      (acc, title) => acc + getSelectedActivityPrice(title),
+      0
+    )
+
+  useEffect(() => {
+    setMessage(
+      `Hello, I would like to get more information about the tour ${tour.title}${selectedActivities.length > 0 ? `, with the activities: ${selectedActivities.join(', ')}` : ''}. With an approximate value of ${totalPrice}`
+    )
+  }, [tour, selectedActivities, totalPrice])
+
+  const handleActivityToggle = (activityTitle: string) => {
+    setSelectedActivities((prev) => {
+      if (prev.includes(activityTitle)) {
+        return prev.filter((title) => title !== activityTitle)
+      }
+      return [...prev, activityTitle]
+    })
+  }
+
+  return (
+    <div className="mx-auto my-14 flex flex-col items-center justify-center gap-12 md:w-6/12">
+      <Link
+        href="/tours"
+        className="text-muted-foreground hover:text-foreground flex items-center gap-2 self-start text-sm transition-colors duration-200"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to tours
+      </Link>
+      <Card className="mx-auto flex w-11/12 flex-col pt-0 md:w-full">
+        <CardHeader className="px-0 pt-0">
+          {tour.images ? (
+            <TourMediaCarousel items={tour.images} />
+          ) : (
+            <Image
+              src={tour.image}
+              alt={tour.place}
+              width={500}
+              height={500}
+              className="aspect-[4/3] w-full rounded-t-[14px] object-cover"
+            />
+          )}
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="text-muted-foreground flex items-center gap-1">
+              <MapPin />
+              <p>{tour.place}</p>
+            </div>
+            <div className="text-muted-foreground flex items-center gap-1">
+              <Clock />
+              <p>{tour.duration}</p>
+            </div>
+          </div>
+          <h2 className="text-2xl font-bold">{tour.title}</h2>
+          <p className="text-muted-foreground">{tour.description}</p>
+          <h3 className="text-xl font-bold">Highlights:</h3>
+          <ul className="grid list-inside list-disc gap-2 md:grid-cols-2">
+            {tour.highlights.map((highlight) => (
+              <li key={highlight}>{highlight}</li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      {tour.activities.length > 0 && (
+        <h2 className="ml-4 self-start text-2xl font-bold">
+          Available activities:
+        </h2>
+      )}
+      <div className="flex flex-col gap-4">
+        {tour.activities.length > 0
+          ? tour.activities.map((activity) => (
+              <Card
+                key={activity.title}
+                className="mx-auto flex w-11/12 flex-col py-0 md:w-full md:flex-row"
+              >
+                <Image
+                  src={activity.image}
+                  alt={activity.title}
+                  width={200}
+                  height={200}
+                  className="w-full rounded-t-[14px] object-cover md:w-4/12 md:rounded-l-[14px] md:rounded-r-none"
+                />
+                <div className="flex flex-col gap-2 p-4">
+                  <div className="flex w-full items-center justify-between gap-4">
+                    <h3 className="text-xl font-bold">{activity.title}</h3>
+                    <p className="text-muted-foreground">{activity.duration}</p>
+                  </div>
+                  <p className="text-muted-foreground">
+                    {activity.description}
+                  </p>
+                  {activity.includes && (
+                    <div>
+                      <p className="font-bold">Includes:</p>
+                      <ul className="grid grid-cols-2 gap-2">
+                        {activity.includes.map((include: string) => (
+                          <li key={include} className="flex items-center gap-2">
+                            <Check className="text-primary h-4 w-4" />
+                            {include}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  <div className="flex items-center justify-between">
+                    <p className="text-secondary text-xl font-bold">
+                      ${Number(activity.price).toLocaleString()}
+                    </p>
+                    <Button
+                      variant={
+                        selectedActivities.includes(activity.title)
+                          ? 'outline'
+                          : 'default'
+                      }
+                      onClick={() => handleActivityToggle(activity.title)}
+                    >
+                      {selectedActivities.includes(activity.title)
+                        ? 'Remove from my experience'
+                        : 'Add to my experience'}
+                    </Button>
+                  </div>
+                </div>
+              </Card>
+            ))
+          : null}
+      </div>
+      <Card className="mx-auto w-11/12 px-4 md:w-full">
+        <CardHeader>
+          <h2 className="text-2xl font-bold">Summary of your experience</h2>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <p className="text-muted-foreground">Base price:</p>
+              <p className="text-lg font-bold">
+                ${Number(tour.price).toLocaleString()} / person
+              </p>
+            </div>
+            {selectedActivities.length > 0 && (
+              <>
+                <div className="border-t pt-4">
+                  <p className="mb-2 font-bold">Selected activities:</p>
+                  {selectedActivities.map((title) => (
+                    <div
+                      key={title}
+                      className="flex items-center justify-between"
+                    >
+                      <p className="text-muted-foreground">{title}</p>
+                      <p className="font-bold">
+                        $
+                        {Number(
+                          getSelectedActivityPrice(title)
+                        ).toLocaleString()}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+                <div className="border-t pt-4">
+                  <div className="flex items-center justify-between">
+                    <p className="text-lg font-bold">Total:</p>
+                    <p className="text-lg font-bold">
+                      ${Number(totalPrice).toLocaleString()}
+                    </p>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </CardHeader>
+        <Button
+          className="flex w-full items-center gap-2 bg-green-500 text-white hover:bg-green-600"
+          asChild
+        >
+          <Link
+            href={`https://wa.me/${CONTACT.phone}?text=${encodeURIComponent(message)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Image
+              src={images.whatsapp}
+              alt="whatsapp"
+              width={20}
+              height={20}
+            />
+            <p>Consult by Whatsapp</p>
+          </Link>
+        </Button>
+      </Card>
+      <div className="flex justify-center"></div>
+    </div>
+  )
+}

--- a/src/app/tours/__tests__/tour-detail.test.tsx
+++ b/src/app/tours/__tests__/tour-detail.test.tsx
@@ -1,82 +1,74 @@
-import TourPage from '@/app/tours/[name]/page'
+import TourClient, { type Tour } from '@/app/tours/[name]/tour-client'
 import { fireEvent, render, screen } from '@testing-library/react'
-
-const mockUseParams = vi.fn().mockReturnValue({ name: 'test-tour' })
 
 vi.mock('@/components/ui/tour-media-carousel', () => ({
   TourMediaCarousel: () => <div data-testid="tour-media-carousel" />,
 }))
 
 vi.mock('next/navigation', () => ({
-  useParams: () => mockUseParams(),
-  useRouter: () => ({ push: vi.fn() }),
   usePathname: () => '/',
+  useRouter: () => ({ push: vi.fn() }),
   useSearchParams: () => new URLSearchParams(),
 }))
 
 vi.mock('@/lib/data', () => ({
-  TOURS: [
-    {
-      place: 'Test Place',
-      title: 'Test Tour',
-      description: 'Test description',
-      image: 'https://res.cloudinary.com/test/image.jpg',
-      images: [
-        {
-          type: 'image',
-          url: 'https://res.cloudinary.com/test/img.jpg',
-          alt: 'img',
-        },
-      ],
-      duration: '8 hours',
-      highlights: ['Highlight 1', 'Highlight 2'],
-      href: '/tours/test-tour',
-      price: 100,
-      activities: [
-        {
-          title: 'Activity 1',
-          description: 'Activity description',
-          image: 'https://res.cloudinary.com/test/activity.jpg',
-          duration: '2 hours',
-          includes: ['Item 1', 'Item 2'],
-          price: 50,
-        },
-        {
-          title: 'Activity 2',
-          description: 'No includes activity',
-          image: 'https://res.cloudinary.com/test/activity2.jpg',
-          price: 30,
-        },
-      ],
-    },
-    {
-      place: 'No Activities Place',
-      title: 'No Activities Tour',
-      description: 'No activities',
-      image: 'https://res.cloudinary.com/test/image2.jpg',
-      duration: '4 hours',
-      highlights: ['Highlight A'],
-      href: '/tours/no-activities',
-      price: 80,
-      activities: [],
-    },
-  ],
-  CONTACT: { phone: '1234567890', email: 'test@test.com' },
-  HEADER_LINKS: [],
+  CONTACT: { email: 'test@test.com', phone: '1234567890' },
 }))
 
-describe('Tour detail page', () => {
-  beforeEach(() => {
-    mockUseParams.mockReturnValue({ name: 'test-tour' })
-  })
+const testTour: Tour = {
+  activities: [
+    {
+      description: 'Activity description',
+      duration: '2 hours',
+      image: 'https://res.cloudinary.com/test/activity.jpg',
+      includes: ['Item 1', 'Item 2'],
+      price: 50,
+      title: 'Activity 1',
+    },
+    {
+      description: 'No includes activity',
+      image: 'https://res.cloudinary.com/test/activity2.jpg',
+      price: 30,
+      title: 'Activity 2',
+    },
+  ],
+  description: 'Test description',
+  duration: '8 hours',
+  highlights: ['Highlight 1', 'Highlight 2'],
+  href: '/tours/test-tour',
+  image: 'https://res.cloudinary.com/test/image.jpg',
+  images: [
+    {
+      alt: 'img',
+      type: 'image',
+      url: 'https://res.cloudinary.com/test/img.jpg',
+    },
+  ],
+  place: 'Test Place',
+  price: 100,
+  title: 'Test Tour',
+}
 
+const noActivitiesTour: Tour = {
+  activities: [],
+  description: 'No activities',
+  duration: '4 hours',
+  highlights: ['Highlight A'],
+  href: '/tours/no-activities',
+  image: 'https://res.cloudinary.com/test/image2.jpg',
+  place: 'No Activities Place',
+  price: 80,
+  title: 'No Activities Tour',
+}
+
+describe('Tour detail page', () => {
   it('renders the tour title', () => {
-    render(<TourPage />)
+    render(<TourClient tour={testTour} />)
     expect(screen.getByText('Test Tour')).toBeInTheDocument()
   })
 
   it('all target="_blank" links have rel="noopener noreferrer"', () => {
-    render(<TourPage />)
+    render(<TourClient tour={testTour} />)
     const externalLinks = document.querySelectorAll('a[target="_blank"]')
     externalLinks.forEach((link) => {
       expect(link.getAttribute('rel')).toBe('noopener noreferrer')
@@ -84,12 +76,12 @@ describe('Tour detail page', () => {
   })
 
   it('renders highlights', () => {
-    render(<TourPage />)
+    render(<TourClient tour={testTour} />)
     expect(screen.getByText('Highlight 1')).toBeInTheDocument()
   })
 
   it('renders activities and toggles selection', () => {
-    render(<TourPage />)
+    render(<TourClient tour={testTour} />)
     expect(screen.getByText('Activity 1')).toBeInTheDocument()
     const addBtns = screen.getAllByText('Add to my experience')
     fireEvent.click(addBtns[0])
@@ -100,14 +92,8 @@ describe('Tour detail page', () => {
     )
   })
 
-  it('renders "tour not found" when tour does not exist', () => {
-    mockUseParams.mockReturnValueOnce({ name: 'non-existent' })
-    render(<TourPage />)
-    expect(screen.getByText('Tour not found')).toBeInTheDocument()
-  })
-
   it('shows selected activity summary and total price', () => {
-    render(<TourPage />)
+    render(<TourClient tour={testTour} />)
     const addBtns = screen.getAllByText('Add to my experience')
     fireEvent.click(addBtns[0])
     expect(screen.getByText('Selected activities:')).toBeInTheDocument()
@@ -115,8 +101,7 @@ describe('Tour detail page', () => {
   })
 
   it('renders tour with no activities', () => {
-    mockUseParams.mockReturnValue({ name: 'no-activities' })
-    render(<TourPage />)
+    render(<TourClient tour={noActivitiesTour} />)
     expect(screen.getByText('No Activities Tour')).toBeInTheDocument()
     expect(screen.queryByText('Available activities:')).not.toBeInTheDocument()
   })


### PR DESCRIPTION
## What and why
Every tour page shared the same generic title and description because \`tours/[name]/page.tsx\` was a client component and can't export \`generateMetadata\`. Search engines indexed all tour pages as duplicates. This splits the page into a server component (for metadata) and a client component (for interactive logic).

## Changes
- Rewrite \`src/app/tours/[name]/page.tsx\` as an async server component that exports \`generateMetadata\` — returns unique title, description, and OG image per tour
- Extract all client-side UI and state logic into \`src/app/tours/[name]/tour-client.tsx\` (new file), which receives the resolved \`tour\` object as a prop
- Update \`src/app/tours/__tests__/tour-detail.test.tsx\` to test \`TourClient\` directly with a \`tour\` prop instead of the server page with mocked \`useParams\`

## Type of change
- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Chore / refactor (no behaviour change)
- [ ] Breaking change (existing functionality is affected)

## Test plan
- [ ] Visit \`/tours/guatape\` — browser tab title shows "Guatapé" (not the generic site title)
- [ ] Share a tour URL in Slack/iMessage — OG card shows the tour image and title
- [ ] Visit \`/tours/non-existent\` — renders Next.js 404, not a blank page
- [ ] All interactive features work: activity toggle, price summary, WhatsApp link
- [ ] Run \`bun run type-check\` — no type errors

## Notes for reviewer
The "tour not found" case previously rendered inline JSX inside the client component. It now calls Next.js \`notFound()\` in the server component, which renders the nearest \`not-found.tsx\` (or the default Next.js 404). No \`not-found.tsx\` exists in the repo yet so the default is used — that's acceptable for now.

---
Linear: https://linear.app/lesteban/issue/LES-79/add-dynamic-metadata-per-tour-page