### PR TITLE
chore: Achieve 100% test coverage across all source files (LES-124)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: Unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,4 +16,17 @@ jobs:
         with:
           bun-version: latest
       - run: bun install
-      - run: bun test:coverage
+      - name: Run tests
+        run: bunx vitest run
+
+  coverage:
+    name: Coverage (100% required)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - name: Enforce 100% coverage
+        run: bun run test:coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,9 @@ bun run lint         # ESLint
 bun run format       # Prettier format
 bun run format:check # Prettier check
 bun run type-check   # TypeScript type check (tsc --noEmit)
-bun test             # Run Vitest tests
-bun test:ui          # Vitest interactive UI
-bun test:coverage    # Vitest with coverage
+bun run test         # Run Vitest tests
+bun run test:ui      # Vitest interactive UI
+bun run test:coverage # Vitest with coverage (100% threshold enforced)
 ```
 
 CI runs lint, typecheck, and test as parallel jobs on PR to `main`/`develop`, and on push to `main` only (no double-run on merge). Branches are auto-deleted after PR close except `develop` and `main`.
@@ -43,7 +43,7 @@ CI runs lint, typecheck, and test as parallel jobs on PR to `main`/`develop`, an
 
 ## Testing
 
-Vitest + jsdom + Testing Library. Test setup at `src/test/setup.ts` provides mocks for Next.js router, Image, Link, and fonts. **Known**: 20 tests in the suite have pre-existing failures (jsdom/font-mock issues) unrelated to feature code — baseline is 14 pass / 20 fail on `develop`. Run a single test file with:
+Vitest + jsdom + Testing Library. Test setup at `src/test/setup.ts` provides mocks for Next.js router, Image, Link, fonts, and `HTMLMediaElement`. Coverage is enforced at 100% (branches/functions/lines/statements) via vitest.config.ts thresholds — CI fails if coverage drops. Run a single test file with:
 
 ```bash
 bunx vitest run src/components/__tests__/button.test.tsx

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type-check": "tsc --noEmit",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:coverage": "vitest --coverage"
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@fortawesome/free-brands-svg-icons": "^6.7.2",

--- a/src/app/__tests__/home.test.tsx
+++ b/src/app/__tests__/home.test.tsx
@@ -1,0 +1,13 @@
+import Home from '@/app/page'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('@/components/ui/carousel-home', () => ({
+  CarouselHome: () => <div data-testid="carousel-home" />,
+}))
+
+describe('Home page', () => {
+  it('renders CarouselHome', () => {
+    render(<Home />)
+    expect(screen.getByTestId('carousel-home')).toBeInTheDocument()
+  })
+})

--- a/src/app/__tests__/robots.test.ts
+++ b/src/app/__tests__/robots.test.ts
@@ -1,0 +1,10 @@
+import robots from '@/app/robots'
+
+describe('robots', () => {
+  it('returns the correct robots configuration', () => {
+    expect(robots()).toEqual({
+      rules: { allow: '/', userAgent: '*' },
+      sitemap: 'https://roadmapcol.com/sitemap.xml',
+    })
+  })
+})

--- a/src/app/__tests__/sitemap.test.ts
+++ b/src/app/__tests__/sitemap.test.ts
@@ -1,0 +1,28 @@
+import sitemap from '@/app/sitemap'
+
+vi.mock('@/lib/data', () => ({
+  TOURS: [
+    { href: '/tours/tour-1', title: 'Tour 1' },
+    { href: '/tours/tour-2', title: 'Tour 2' },
+    { href: '/tours/tour-1', title: 'Tour 1 duplicate' },
+  ],
+}))
+
+describe('sitemap', () => {
+  it('includes all static routes', () => {
+    const urls = sitemap().map((r) => r.url)
+    expect(urls).toContain('https://roadmapcol.com')
+    expect(urls).toContain('https://roadmapcol.com/tours')
+    expect(urls).toContain('https://roadmapcol.com/personalize')
+  })
+
+  it('includes unique tour routes', () => {
+    const urls = sitemap().map((r) => r.url)
+    expect(urls).toContain('https://roadmapcol.com/tours/tour-1')
+    expect(urls).toContain('https://roadmapcol.com/tours/tour-2')
+    const duplicates = urls.filter(
+      (u) => u === 'https://roadmapcol.com/tours/tour-1'
+    )
+    expect(duplicates).toHaveLength(1)
+  })
+})

--- a/src/app/tours/__tests__/tour-detail.test.tsx
+++ b/src/app/tours/__tests__/tour-detail.test.tsx
@@ -105,4 +105,21 @@ describe('Tour detail page', () => {
     expect(screen.getByText('No Activities Tour')).toBeInTheDocument()
     expect(screen.queryByText('Available activities:')).not.toBeInTheDocument()
   })
+
+  it('treats activity with no price as $0', () => {
+    const tourWithPricelessActivity: Tour = {
+      ...testTour,
+      activities: [
+        {
+          description: 'Free activity',
+          image: 'https://res.cloudinary.com/test/free.jpg',
+          title: 'Free Activity',
+        },
+      ],
+    }
+    render(<TourClient tour={tourWithPricelessActivity} />)
+    const addBtn = screen.getByText('Add to my experience')
+    fireEvent.click(addBtn)
+    expect(screen.getByText('Selected activities:')).toBeInTheDocument()
+  })
 })

--- a/src/app/tours/__tests__/tour-page.test.tsx
+++ b/src/app/tours/__tests__/tour-page.test.tsx
@@ -1,0 +1,70 @@
+import TourPage, { generateMetadata } from '@/app/tours/[name]/page'
+import { render, screen } from '@testing-library/react'
+import { notFound } from 'next/navigation'
+
+vi.mock('@/lib/data', () => ({
+  TOURS: [
+    {
+      activities: [],
+      description: 'Test description',
+      duration: '8 hours',
+      highlights: ['Highlight 1'],
+      href: '/tours/test-tour',
+      image: 'https://res.cloudinary.com/test/image.jpg',
+      place: 'Test Place',
+      price: 100,
+      title: 'Test Tour',
+    },
+  ],
+}))
+
+vi.mock('@/app/tours/[name]/tour-client', () => ({
+  default: ({ tour }: { tour: { title: string } }) => (
+    <div data-testid="tour-client">{tour.title}</div>
+  ),
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND')
+  }),
+  useParams: () => ({}),
+  usePathname: () => '/',
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+describe('TourPage', () => {
+  it('renders TourClient for a valid tour', async () => {
+    const element = await TourPage({
+      params: Promise.resolve({ name: 'test-tour' }),
+    })
+    render(element)
+    expect(screen.getByTestId('tour-client')).toBeInTheDocument()
+    expect(screen.getByText('Test Tour')).toBeInTheDocument()
+  })
+
+  it('calls notFound for an unknown tour slug', async () => {
+    await expect(
+      TourPage({ params: Promise.resolve({ name: 'unknown' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND')
+    expect(notFound).toHaveBeenCalled()
+  })
+})
+
+describe('generateMetadata', () => {
+  it('returns metadata for a valid tour', async () => {
+    const result = await generateMetadata({
+      params: Promise.resolve({ name: 'test-tour' }),
+    })
+    expect(result.title).toBe('Test Tour')
+    expect(result.description).toBe('Test description')
+  })
+
+  it('returns empty object for an unknown tour', async () => {
+    const result = await generateMetadata({
+      params: Promise.resolve({ name: 'unknown' }),
+    })
+    expect(result).toEqual({})
+  })
+})

--- a/src/components/__tests__/gtm.test.tsx
+++ b/src/components/__tests__/gtm.test.tsx
@@ -13,10 +13,14 @@ vi.mock('next/navigation', () => ({
   useSearchParams: vi.fn(() => new URLSearchParams()),
 }))
 
+type SearchParamsReturn = ReturnType<typeof useSearchParams>
+
 describe('GTM', () => {
   afterEach(() => {
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as any)
-    delete (window as any).dataLayer
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams() as unknown as SearchParamsReturn
+    )
+    delete window.dataLayer
   })
 
   it('renders the GTM script tag', () => {
@@ -34,12 +38,12 @@ describe('GTM', () => {
 
   it('includes search params in the pageview page value when present', () => {
     vi.mocked(useSearchParams).mockReturnValue(
-      new URLSearchParams('tour=medellin') as any
+      new URLSearchParams('tour=medellin') as unknown as SearchParamsReturn
     )
     window.dataLayer = []
     render(<GTM />)
-    const entry = window.dataLayer.find((e) => e['event'] === 'pageview') as any
-    expect(entry?.page).toContain('tour=medellin')
+    const entry = window.dataLayer.find((e) => e['event'] === 'pageview')
+    expect(String(entry?.['page'])).toContain('tour=medellin')
   })
 })
 

--- a/src/components/__tests__/gtm.test.tsx
+++ b/src/components/__tests__/gtm.test.tsx
@@ -1,0 +1,51 @@
+import { GTM, GTMNoscript } from '@/components/gtm'
+import { render } from '@testing-library/react'
+import { useSearchParams } from 'next/navigation'
+
+vi.mock('next/script', () => ({
+  default: ({ id }: { id: string }) => <script id={id} />,
+}))
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({}),
+  usePathname: () => '/',
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}))
+
+describe('GTM', () => {
+  afterEach(() => {
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams() as any)
+    delete (window as any).dataLayer
+  })
+
+  it('renders the GTM script tag', () => {
+    render(<GTM />)
+    expect(document.getElementById('gtm-script')).toBeInTheDocument()
+  })
+
+  it('pushes a pageview without search params to dataLayer', () => {
+    window.dataLayer = []
+    render(<GTM />)
+    expect(
+      window.dataLayer.some((entry) => entry['event'] === 'pageview')
+    ).toBe(true)
+  })
+
+  it('includes search params in the pageview page value when present', () => {
+    vi.mocked(useSearchParams).mockReturnValue(
+      new URLSearchParams('tour=medellin') as any
+    )
+    window.dataLayer = []
+    render(<GTM />)
+    const entry = window.dataLayer.find((e) => e['event'] === 'pageview') as any
+    expect(entry?.page).toContain('tour=medellin')
+  })
+})
+
+describe('GTMNoscript', () => {
+  it('renders a noscript element', () => {
+    render(<GTMNoscript />)
+    expect(document.querySelector('noscript')).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/tour-gallery.test.tsx
+++ b/src/components/__tests__/tour-gallery.test.tsx
@@ -1,0 +1,34 @@
+import { TourGallery } from '@/components/tour-gallery'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('@/components/ui/carousel', () => ({
+  MediaCarousel: ({ items }: { items: { alt: string }[] }) => (
+    <div data-testid="media-carousel">
+      {items.map((item) => (
+        <span key={item.alt}>{item.alt}</span>
+      ))}
+    </div>
+  ),
+}))
+
+describe('TourGallery', () => {
+  const images = [
+    {
+      alt: 'Image 1',
+      type: 'image' as const,
+      url: 'https://example.com/1.jpg',
+    },
+    {
+      alt: 'Video 1',
+      type: 'video' as const,
+      url: 'https://example.com/1.mp4',
+    },
+  ]
+
+  it('renders MediaCarousel with all items', () => {
+    render(<TourGallery images={images} />)
+    expect(screen.getByTestId('media-carousel')).toBeInTheDocument()
+    expect(screen.getByText('Image 1')).toBeInTheDocument()
+    expect(screen.getByText('Video 1')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/__tests__/badge.test.tsx
+++ b/src/components/ui/__tests__/badge.test.tsx
@@ -1,0 +1,33 @@
+import { Badge } from '@/components/ui/badge'
+import { render, screen } from '@testing-library/react'
+
+describe('Badge', () => {
+  it('renders with default variant', () => {
+    render(<Badge>Default</Badge>)
+    expect(screen.getByText('Default')).toBeInTheDocument()
+  })
+
+  it('renders with secondary variant', () => {
+    render(<Badge variant="secondary">Secondary</Badge>)
+    expect(screen.getByText('Secondary')).toBeInTheDocument()
+  })
+
+  it('renders with destructive variant', () => {
+    render(<Badge variant="destructive">Destructive</Badge>)
+    expect(screen.getByText('Destructive')).toBeInTheDocument()
+  })
+
+  it('renders with outline variant', () => {
+    render(<Badge variant="outline">Outline</Badge>)
+    expect(screen.getByText('Outline')).toBeInTheDocument()
+  })
+
+  it('renders as child when asChild is true', () => {
+    render(
+      <Badge asChild>
+        <span>Child</span>
+      </Badge>
+    )
+    expect(screen.getByText('Child')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/__tests__/card.test.tsx
+++ b/src/components/ui/__tests__/card.test.tsx
@@ -1,0 +1,47 @@
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { render, screen } from '@testing-library/react'
+
+describe('Card components', () => {
+  it('renders Card', () => {
+    render(<Card data-testid="card">content</Card>)
+    expect(screen.getByTestId('card')).toBeInTheDocument()
+  })
+
+  it('renders CardHeader', () => {
+    render(<CardHeader data-testid="header">header</CardHeader>)
+    expect(screen.getByTestId('header')).toBeInTheDocument()
+  })
+
+  it('renders CardTitle', () => {
+    render(<CardTitle>Title text</CardTitle>)
+    expect(screen.getByText('Title text')).toBeInTheDocument()
+  })
+
+  it('renders CardDescription', () => {
+    render(<CardDescription>Description text</CardDescription>)
+    expect(screen.getByText('Description text')).toBeInTheDocument()
+  })
+
+  it('renders CardAction', () => {
+    render(<CardAction>Action</CardAction>)
+    expect(screen.getByText('Action')).toBeInTheDocument()
+  })
+
+  it('renders CardContent', () => {
+    render(<CardContent>Content</CardContent>)
+    expect(screen.getByText('Content')).toBeInTheDocument()
+  })
+
+  it('renders CardFooter', () => {
+    render(<CardFooter>Footer</CardFooter>)
+    expect(screen.getByText('Footer')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/__tests__/carousel-home.test.tsx
+++ b/src/components/ui/__tests__/carousel-home.test.tsx
@@ -1,6 +1,9 @@
 import { CarouselHome } from '@/components/ui/carousel-home'
 import { fireEvent, render, screen } from '@testing-library/react'
-import useEmblaCarousel from 'embla-carousel-react'
+import type { EmblaCarouselType } from 'embla-carousel'
+import useEmblaCarousel, {
+  type EmblaViewportRefType,
+} from 'embla-carousel-react'
 
 vi.mock('embla-carousel-react', () => ({
   default: vi.fn(),
@@ -57,11 +60,13 @@ const buildMockApi = () => ({
   selectedScrollSnap: vi.fn(() => 0),
 })
 
+const mockRef = vi.fn() as unknown as EmblaViewportRefType
+
 describe('CarouselHome', () => {
   beforeEach(() => {
     vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      buildMockApi() as any,
+      mockRef,
+      buildMockApi() as unknown as EmblaCarouselType,
     ])
   })
 
@@ -96,10 +101,7 @@ describe('CarouselHome', () => {
   })
 
   it('renders without error when embla api is undefined', () => {
-    vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      undefined as any,
-    ])
+    vi.mocked(useEmblaCarousel).mockReturnValue([mockRef, undefined])
     render(<CarouselHome />)
     expect(screen.getByText('Road Map Col')).toBeInTheDocument()
   })

--- a/src/components/ui/__tests__/carousel-home.test.tsx
+++ b/src/components/ui/__tests__/carousel-home.test.tsx
@@ -1,0 +1,106 @@
+import { CarouselHome } from '@/components/ui/carousel-home'
+import { fireEvent, render, screen } from '@testing-library/react'
+import useEmblaCarousel from 'embla-carousel-react'
+
+vi.mock('embla-carousel-react', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('embla-carousel-autoplay', () => ({
+  default: vi.fn(() => ({
+    destroy: vi.fn(),
+    init: vi.fn(),
+    name: 'autoplay',
+    options: {},
+    play: vi.fn(),
+    reset: vi.fn(),
+    stop: vi.fn(),
+  })),
+}))
+
+vi.mock('@/lib/data', () => ({
+  LANDING_LINKS: [
+    {
+      button: 'Learn more',
+      chip: 'About us',
+      chipColor: 'bg-sky-200',
+      chipIcon: null,
+      description: 'Test description',
+      href: '/tours',
+      image: 'https://example.com/img.jpg',
+      subtitle: 'Test subtitle',
+      title: 'Road Map Col',
+    },
+    {
+      button: 'Explore',
+      chip: 'Tour',
+      chipColor: 'bg-green-200',
+      chipIcon: null,
+      description: 'Another description',
+      href: '/personalize',
+      image: 'https://example.com/img2.jpg',
+      subtitle: 'Another subtitle',
+      title: 'Explore Colombia',
+    },
+  ],
+}))
+
+const buildMockApi = () => ({
+  canScrollNext: vi.fn(() => true),
+  canScrollPrev: vi.fn(() => true),
+  off: vi.fn(),
+  on: vi.fn(),
+  scrollNext: vi.fn(),
+  scrollPrev: vi.fn(),
+  scrollSnapList: vi.fn(() => [0, 1]),
+  scrollTo: vi.fn(),
+  selectedScrollSnap: vi.fn(() => 0),
+})
+
+describe('CarouselHome', () => {
+  beforeEach(() => {
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      buildMockApi() as any,
+    ])
+  })
+
+  it('renders all landing link cards', () => {
+    render(<CarouselHome />)
+    expect(screen.getByText('Road Map Col')).toBeInTheDocument()
+    expect(screen.getByText('Explore Colombia')).toBeInTheDocument()
+  })
+
+  it('renders chip labels', () => {
+    render(<CarouselHome />)
+    expect(screen.getByText('About us')).toBeInTheDocument()
+    expect(screen.getByText('Tour')).toBeInTheDocument()
+  })
+
+  it('clicking a card button does not crash', () => {
+    render(<CarouselHome />)
+    const learnMoreBtn = screen.getAllByText('Learn more')[0]
+    fireEvent.click(learnMoreBtn)
+  })
+
+  it('clicking previous/next does not crash', () => {
+    render(<CarouselHome />)
+    fireEvent.click(screen.getByText('Previous slide').closest('button')!)
+    fireEvent.click(screen.getByText('Next slide').closest('button')!)
+  })
+
+  it('renders previous and next controls', () => {
+    render(<CarouselHome />)
+    expect(screen.getByText('Previous slide')).toBeInTheDocument()
+    expect(screen.getByText('Next slide')).toBeInTheDocument()
+  })
+
+  it('renders without error when embla api is undefined', () => {
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      undefined as any,
+    ])
+    render(<CarouselHome />)
+    expect(screen.getByText('Road Map Col')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/__tests__/carousel-pagination.test.tsx
+++ b/src/components/ui/__tests__/carousel-pagination.test.tsx
@@ -1,0 +1,27 @@
+import { CarouselPagination } from '@/components/ui/carousel-pagination'
+import { render, screen } from '@testing-library/react'
+
+describe('CarouselPagination', () => {
+  it('renders the correct number of dot buttons', () => {
+    render(<CarouselPagination currentSlide={0} totalSlides={3} />)
+    expect(screen.getAllByRole('button')).toHaveLength(3)
+  })
+
+  it('gives each button the correct aria-label', () => {
+    render(<CarouselPagination currentSlide={1} totalSlides={3} />)
+    expect(
+      screen.getByRole('button', { name: 'Go to slide 2' })
+    ).toBeInTheDocument()
+  })
+
+  it('accepts an optional className', () => {
+    render(
+      <CarouselPagination
+        currentSlide={0}
+        totalSlides={2}
+        className="custom-class"
+      />
+    )
+    expect(screen.getAllByRole('button')).toHaveLength(2)
+  })
+})

--- a/src/components/ui/__tests__/carousel.test.tsx
+++ b/src/components/ui/__tests__/carousel.test.tsx
@@ -7,7 +7,10 @@ import {
   MediaCarousel,
 } from '@/components/ui/carousel'
 import { fireEvent, render, screen } from '@testing-library/react'
-import useEmblaCarousel from 'embla-carousel-react'
+import type { EmblaCarouselType } from 'embla-carousel'
+import useEmblaCarousel, {
+  type EmblaViewportRefType,
+} from 'embla-carousel-react'
 
 vi.mock('embla-carousel-react', () => ({
   default: vi.fn(),
@@ -29,10 +32,12 @@ const buildMockApi = (canScrollPrev = false, canScrollNext = true) => ({
   selectedScrollSnap: vi.fn(() => 1),
 })
 
+const mockRef = vi.fn() as unknown as EmblaViewportRefType
+
 beforeEach(() => {
   vi.mocked(useEmblaCarousel).mockReturnValue([
-    vi.fn() as any,
-    buildMockApi() as any,
+    mockRef,
+    buildMockApi() as unknown as EmblaCarouselType,
   ])
 })
 
@@ -51,8 +56,8 @@ describe('Carousel', () => {
   it('handles ArrowLeft key to scroll prev', () => {
     const mockApi = buildMockApi()
     vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      mockApi as any,
+      mockRef,
+      mockApi as unknown as EmblaCarouselType,
     ])
     render(
       <Carousel>
@@ -69,8 +74,8 @@ describe('Carousel', () => {
   it('handles ArrowRight key to scroll next', () => {
     const mockApi = buildMockApi()
     vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      mockApi as any,
+      mockRef,
+      mockApi as unknown as EmblaCarouselType,
     ])
     render(
       <Carousel>
@@ -87,8 +92,8 @@ describe('Carousel', () => {
   it('ignores unrelated key presses', () => {
     const mockApi = buildMockApi()
     vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      mockApi as any,
+      mockRef,
+      mockApi as unknown as EmblaCarouselType,
     ])
     render(
       <Carousel>
@@ -116,10 +121,7 @@ describe('Carousel', () => {
   })
 
   it('does not crash when embla api is undefined', () => {
-    vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      undefined as any,
-    ])
+    vi.mocked(useEmblaCarousel).mockReturnValue([mockRef, undefined])
     render(
       <Carousel>
         <CarouselContent>
@@ -144,8 +146,8 @@ describe('Carousel', () => {
   it('cleans up event listener on unmount', () => {
     const mockApi = buildMockApi()
     vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      mockApi as any,
+      mockRef,
+      mockApi as unknown as EmblaCarouselType,
     ])
     const { unmount } = render(
       <Carousel>
@@ -176,8 +178,8 @@ describe('CarouselPrevious and CarouselNext', () => {
 
   it('previous button is disabled when canScrollPrev is false', () => {
     vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      buildMockApi(false, true) as any,
+      mockRef,
+      buildMockApi(false, true) as unknown as EmblaCarouselType,
     ])
     render(
       <Carousel>
@@ -196,8 +198,8 @@ describe('CarouselPrevious and CarouselNext', () => {
 
   it('next button is enabled when canScrollNext is true', () => {
     vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      buildMockApi(false, true) as any,
+      mockRef,
+      buildMockApi(false, true) as unknown as EmblaCarouselType,
     ])
     render(
       <Carousel>
@@ -275,8 +277,8 @@ describe('MediaCarousel', () => {
   it('clicking prev/next scrolls media carousel', () => {
     const mockApi = buildMockApi()
     vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      mockApi as any,
+      mockRef,
+      mockApi as unknown as EmblaCarouselType,
     ])
     render(
       <MediaCarousel
@@ -296,8 +298,8 @@ describe('MediaCarousel', () => {
   it('clicking a dot scrolls to that index', () => {
     const mockApi = buildMockApi()
     vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      mockApi as any,
+      mockRef,
+      mockApi as unknown as EmblaCarouselType,
     ])
     render(
       <MediaCarousel
@@ -311,10 +313,7 @@ describe('MediaCarousel', () => {
   })
 
   it('renders without error when embla api is undefined', () => {
-    vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      undefined as any,
-    ])
+    vi.mocked(useEmblaCarousel).mockReturnValue([mockRef, undefined])
     render(
       <MediaCarousel
         items={[{ alt: 'A', type: 'image', url: 'https://example.com/a.jpg' }]}

--- a/src/components/ui/__tests__/carousel.test.tsx
+++ b/src/components/ui/__tests__/carousel.test.tsx
@@ -1,0 +1,325 @@
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+  MediaCarousel,
+} from '@/components/ui/carousel'
+import { fireEvent, render, screen } from '@testing-library/react'
+import useEmblaCarousel from 'embla-carousel-react'
+
+vi.mock('embla-carousel-react', () => ({
+  default: vi.fn(),
+}))
+
+const buildMockApi = (canScrollPrev = false, canScrollNext = true) => ({
+  canScrollNext: vi.fn(() => canScrollNext),
+  canScrollPrev: vi.fn(() => canScrollPrev),
+  off: vi.fn(),
+  on: vi
+    .fn()
+    .mockImplementation((event: string, cb: (api: unknown) => void) => {
+      if (event === 'reInit') cb(undefined)
+    }),
+  scrollNext: vi.fn(),
+  scrollPrev: vi.fn(),
+  scrollSnapList: vi.fn(() => [0, 1, 2]),
+  scrollTo: vi.fn(),
+  selectedScrollSnap: vi.fn(() => 1),
+})
+
+beforeEach(() => {
+  vi.mocked(useEmblaCarousel).mockReturnValue([
+    vi.fn() as any,
+    buildMockApi() as any,
+  ])
+})
+
+describe('Carousel', () => {
+  it('renders children', () => {
+    render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide 1</CarouselItem>
+        </CarouselContent>
+      </Carousel>
+    )
+    expect(screen.getByText('Slide 1')).toBeInTheDocument()
+  })
+
+  it('handles ArrowLeft key to scroll prev', () => {
+    const mockApi = buildMockApi()
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      mockApi as any,
+    ])
+    render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+      </Carousel>
+    )
+    const carouselEl = document.querySelector('[data-slot="carousel"]')!
+    fireEvent.keyDown(carouselEl, { key: 'ArrowLeft' })
+    expect(mockApi.scrollPrev).toHaveBeenCalled()
+  })
+
+  it('handles ArrowRight key to scroll next', () => {
+    const mockApi = buildMockApi()
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      mockApi as any,
+    ])
+    render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+      </Carousel>
+    )
+    const carouselEl = document.querySelector('[data-slot="carousel"]')!
+    fireEvent.keyDown(carouselEl, { key: 'ArrowRight' })
+    expect(mockApi.scrollNext).toHaveBeenCalled()
+  })
+
+  it('ignores unrelated key presses', () => {
+    const mockApi = buildMockApi()
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      mockApi as any,
+    ])
+    render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+      </Carousel>
+    )
+    const carouselEl = document.querySelector('[data-slot="carousel"]')!
+    fireEvent.keyDown(carouselEl, { key: 'Enter' })
+    expect(mockApi.scrollPrev).not.toHaveBeenCalled()
+    expect(mockApi.scrollNext).not.toHaveBeenCalled()
+  })
+
+  it('calls setApi when provided', () => {
+    const setApi = vi.fn()
+    render(
+      <Carousel setApi={setApi}>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+      </Carousel>
+    )
+    expect(setApi).toHaveBeenCalled()
+  })
+
+  it('does not crash when embla api is undefined', () => {
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      undefined as any,
+    ])
+    render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+      </Carousel>
+    )
+    expect(screen.getByText('Slide')).toBeInTheDocument()
+  })
+
+  it('renders vertical orientation', () => {
+    render(
+      <Carousel orientation="vertical">
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+      </Carousel>
+    )
+    expect(screen.getByText('Slide')).toBeInTheDocument()
+  })
+
+  it('cleans up event listener on unmount', () => {
+    const mockApi = buildMockApi()
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      mockApi as any,
+    ])
+    const { unmount } = render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+      </Carousel>
+    )
+    unmount()
+    expect(mockApi.off).toHaveBeenCalledWith('select', expect.any(Function))
+  })
+})
+
+describe('CarouselPrevious and CarouselNext', () => {
+  it('renders previous and next buttons', () => {
+    render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+    )
+    expect(screen.getByText('Previous slide')).toBeInTheDocument()
+    expect(screen.getByText('Next slide')).toBeInTheDocument()
+  })
+
+  it('previous button is disabled when canScrollPrev is false', () => {
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      buildMockApi(false, true) as any,
+    ])
+    render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+    )
+    const prevBtn = screen
+      .getByText('Previous slide')
+      .closest('button') as HTMLButtonElement
+    expect(prevBtn.disabled).toBe(true)
+  })
+
+  it('next button is enabled when canScrollNext is true', () => {
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      buildMockApi(false, true) as any,
+    ])
+    render(
+      <Carousel>
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+    )
+    const nextBtn = screen
+      .getByText('Next slide')
+      .closest('button') as HTMLButtonElement
+    expect(nextBtn.disabled).toBe(false)
+  })
+
+  it('renders vertical CarouselPrevious and CarouselNext', () => {
+    render(
+      <Carousel orientation="vertical">
+        <CarouselContent>
+          <CarouselItem>Slide</CarouselItem>
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+    )
+    expect(screen.getByText('Previous slide')).toBeInTheDocument()
+    expect(screen.getByText('Next slide')).toBeInTheDocument()
+  })
+
+  it('throws when CarouselContent is used outside Carousel', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<CarouselContent />)).toThrow(
+      'useCarousel must be used within a <Carousel />'
+    )
+    consoleSpy.mockRestore()
+  })
+})
+
+describe('MediaCarousel', () => {
+  it('renders image items', () => {
+    render(
+      <MediaCarousel
+        items={[
+          { alt: 'Img', type: 'image', url: 'https://example.com/a.jpg' },
+        ]}
+      />
+    )
+    expect(screen.getByAltText('Img')).toBeInTheDocument()
+  })
+
+  it('renders video items with and without thumbnail', () => {
+    render(
+      <MediaCarousel
+        items={[
+          {
+            alt: 'Vid no thumb',
+            type: 'video',
+            url: 'https://example.com/v.mp4',
+          },
+          {
+            alt: 'Vid thumb',
+            thumbnail: 'https://example.com/t.jpg',
+            type: 'video',
+            url: 'https://example.com/v2.mp4',
+          },
+        ]}
+      />
+    )
+    const videos = document.querySelectorAll('video')
+    expect(videos).toHaveLength(2)
+    expect(videos[1]).toHaveAttribute('poster', 'https://example.com/t.jpg')
+  })
+
+  it('clicking prev/next scrolls media carousel', () => {
+    const mockApi = buildMockApi()
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      mockApi as any,
+    ])
+    render(
+      <MediaCarousel
+        items={[
+          { alt: 'A', type: 'image', url: 'https://example.com/a.jpg' },
+          { alt: 'B', type: 'image', url: 'https://example.com/b.jpg' },
+        ]}
+      />
+    )
+    const buttons = screen.getAllByRole('button')
+    fireEvent.click(buttons[0])
+    fireEvent.click(buttons[1])
+    expect(mockApi.scrollPrev).toHaveBeenCalled()
+    expect(mockApi.scrollNext).toHaveBeenCalled()
+  })
+
+  it('clicking a dot scrolls to that index', () => {
+    const mockApi = buildMockApi()
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      mockApi as any,
+    ])
+    render(
+      <MediaCarousel
+        items={[{ alt: 'A', type: 'image', url: 'https://example.com/a.jpg' }]}
+      />
+    )
+    const buttons = screen.getAllByRole('button')
+    const lastBtn = buttons[buttons.length - 1]
+    fireEvent.click(lastBtn)
+    expect(mockApi.scrollTo).toHaveBeenCalled()
+  })
+
+  it('renders without error when embla api is undefined', () => {
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      undefined as any,
+    ])
+    render(
+      <MediaCarousel
+        items={[{ alt: 'A', type: 'image', url: 'https://example.com/a.jpg' }]}
+      />
+    )
+    expect(screen.getByAltText('A')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/__tests__/checkbox.test.tsx
+++ b/src/components/ui/__tests__/checkbox.test.tsx
@@ -1,0 +1,14 @@
+import { Checkbox } from '@/components/ui/checkbox'
+import { render, screen } from '@testing-library/react'
+
+describe('Checkbox', () => {
+  it('renders unchecked by default', () => {
+    render(<Checkbox />)
+    expect(screen.getByRole('checkbox')).not.toBeChecked()
+  })
+
+  it('renders checked when defaultChecked is set', () => {
+    render(<Checkbox defaultChecked />)
+    expect(screen.getByRole('checkbox')).toBeChecked()
+  })
+})

--- a/src/components/ui/__tests__/dropdown-menu.test.tsx
+++ b/src/components/ui/__tests__/dropdown-menu.test.tsx
@@ -1,0 +1,76 @@
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { render, screen } from '@testing-library/react'
+
+describe('DropdownMenu', () => {
+  it('renders trigger button', () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Label</DropdownMenuLabel>
+            <DropdownMenuItem>Item</DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+    expect(screen.getByText('Open')).toBeInTheDocument()
+  })
+
+  it('renders DropdownMenuShortcut', () => {
+    render(<DropdownMenuShortcut>⌘K</DropdownMenuShortcut>)
+    expect(screen.getByText('⌘K')).toBeInTheDocument()
+  })
+
+  it('renders all menu components when open', () => {
+    render(
+      <DropdownMenu open>
+        <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuGroup>
+            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+            <DropdownMenuItem>Cut</DropdownMenuItem>
+            <DropdownMenuItem inset>Paste</DropdownMenuItem>
+            <DropdownMenuItem variant="destructive">Delete</DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuCheckboxItem checked>
+              Check
+              <DropdownMenuShortcut>⌘C</DropdownMenuShortcut>
+            </DropdownMenuCheckboxItem>
+            <DropdownMenuRadioGroup value="b">
+              <DropdownMenuRadioItem value="b">Option B</DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+            <DropdownMenuSub open>
+              <DropdownMenuSubTrigger>More</DropdownMenuSubTrigger>
+              <DropdownMenuPortal>
+                <DropdownMenuSubContent>
+                  <DropdownMenuItem>Sub item</DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuPortal>
+            </DropdownMenuSub>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+    expect(document.body.textContent).toContain('Actions')
+    expect(document.body.textContent).toContain('Cut')
+    expect(document.body.textContent).toContain('Sub item')
+  })
+})

--- a/src/components/ui/__tests__/select.test.tsx
+++ b/src/components/ui/__tests__/select.test.tsx
@@ -1,0 +1,51 @@
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { render, screen } from '@testing-library/react'
+
+describe('Select', () => {
+  it('renders a combobox trigger with placeholder', () => {
+    render(
+      <Select>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick one" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectLabel>Options</SelectLabel>
+            <SelectItem value="a">Option A</SelectItem>
+            <SelectSeparator />
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    )
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+    expect(screen.getByText('Pick one')).toBeInTheDocument()
+  })
+
+  it('renders SelectContent with items when open', () => {
+    render(
+      <Select open>
+        <SelectTrigger>
+          <SelectValue placeholder="Pick" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectLabel>Group</SelectLabel>
+            <SelectItem value="b">Option B</SelectItem>
+            <SelectSeparator />
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    )
+    expect(document.body.textContent).toContain('Option B')
+    expect(document.body.textContent).toContain('Group')
+  })
+})

--- a/src/components/ui/__tests__/tour-media-carousel.test.tsx
+++ b/src/components/ui/__tests__/tour-media-carousel.test.tsx
@@ -1,0 +1,134 @@
+import { TourMediaCarousel } from '@/components/ui/tour-media-carousel'
+import { fireEvent, render, screen } from '@testing-library/react'
+import useEmblaCarousel from 'embla-carousel-react'
+
+vi.mock('embla-carousel-react', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('next/image', () => ({
+  default: ({ alt, ...props }: { alt: string; [k: string]: unknown }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} {...(props as any)} />
+  ),
+}))
+
+const buildMockApi = () => ({
+  off: vi.fn(),
+  on: vi.fn(),
+  scrollNext: vi.fn(),
+  scrollPrev: vi.fn(),
+  scrollSnapList: vi.fn(() => [0, 1]),
+  scrollTo: vi.fn(),
+  selectedScrollSnap: vi.fn(() => 0),
+})
+
+beforeEach(() => {
+  vi.mocked(useEmblaCarousel).mockReturnValue([
+    vi.fn() as any,
+    buildMockApi() as any,
+  ])
+})
+
+const imageItems = [
+  {
+    alt: 'Image 1',
+    type: 'image' as const,
+    url: 'https://res.cloudinary.com/demo/image/upload/a.jpg',
+  },
+  {
+    alt: 'Image 2',
+    type: 'image' as const,
+    url: 'https://res.cloudinary.com/demo/image/upload/b.jpg',
+  },
+]
+
+const videoItems = [
+  {
+    alt: 'Video without thumbnail',
+    type: 'video' as const,
+    url: 'https://example.com/video.mp4',
+  },
+  {
+    alt: 'Video with thumbnail',
+    thumbnail: 'https://example.com/thumb.jpg',
+    type: 'video' as const,
+    url: 'https://example.com/video2.mp4',
+  },
+]
+
+describe('TourMediaCarousel', () => {
+  it('renders image items', () => {
+    render(<TourMediaCarousel items={imageItems} />)
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument()
+    expect(screen.getByAltText('Image 2')).toBeInTheDocument()
+  })
+
+  it('renders video items — uses thumbnail when provided', () => {
+    render(<TourMediaCarousel items={videoItems} />)
+    const videos = document.querySelectorAll('video')
+    expect(videos).toHaveLength(2)
+    expect(videos[1]).toHaveAttribute('poster', 'https://example.com/thumb.jpg')
+  })
+
+  it('renders video items — falls back to videoPoster when no thumbnail', () => {
+    render(<TourMediaCarousel items={videoItems} />)
+    const videos = document.querySelectorAll('video')
+    expect(videos[0]).not.toHaveAttribute(
+      'poster',
+      'https://example.com/thumb.jpg'
+    )
+  })
+
+  it('renders navigation buttons', () => {
+    render(<TourMediaCarousel items={imageItems} />)
+    expect(screen.getAllByRole('button').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders dot indicators from scrollSnapList', () => {
+    render(<TourMediaCarousel items={imageItems} />)
+    expect(screen.getAllByRole('button').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('clicking a dot calls scrollTo', () => {
+    const mockApi = buildMockApi()
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      mockApi as any,
+    ])
+    render(<TourMediaCarousel items={imageItems} />)
+    const buttons = screen.getAllByRole('button')
+    fireEvent.click(buttons[buttons.length - 1])
+    expect(mockApi.scrollTo).toHaveBeenCalled()
+  })
+
+  it('clicking previous/next scrolls the carousel', () => {
+    const mockApi = buildMockApi()
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      mockApi as any,
+    ])
+    render(<TourMediaCarousel items={imageItems} />)
+    const buttons = screen.getAllByRole('button')
+    fireEvent.click(buttons[0])
+    fireEvent.click(buttons[1])
+    expect(mockApi.scrollPrev).toHaveBeenCalled()
+    expect(mockApi.scrollNext).toHaveBeenCalled()
+  })
+
+  it('pauses videos when slide changes', () => {
+    render(<TourMediaCarousel items={videoItems} />)
+    const buttons = screen.getAllByRole('button')
+    fireEvent.click(buttons[0])
+    expect(window.HTMLMediaElement.prototype.pause).toHaveBeenCalled()
+  })
+
+  it('renders without error when embla api is undefined', () => {
+    vi.mocked(useEmblaCarousel).mockReturnValue([
+      vi.fn() as any,
+      undefined as any,
+    ])
+    render(<TourMediaCarousel items={imageItems} />)
+    expect(screen.getByAltText('Image 1')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/__tests__/tour-media-carousel.test.tsx
+++ b/src/components/ui/__tests__/tour-media-carousel.test.tsx
@@ -1,15 +1,18 @@
 import { TourMediaCarousel } from '@/components/ui/tour-media-carousel'
 import { fireEvent, render, screen } from '@testing-library/react'
-import useEmblaCarousel from 'embla-carousel-react'
+import type { EmblaCarouselType } from 'embla-carousel'
+import useEmblaCarousel, {
+  type EmblaViewportRefType,
+} from 'embla-carousel-react'
 
 vi.mock('embla-carousel-react', () => ({
   default: vi.fn(),
 }))
 
 vi.mock('next/image', () => ({
-  default: ({ alt, ...props }: { alt: string; [k: string]: unknown }) => (
+  default: ({ alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) => (
     // eslint-disable-next-line @next/next/no-img-element
-    <img alt={alt} {...(props as any)} />
+    <img alt={alt} {...props} />
   ),
 }))
 
@@ -23,10 +26,12 @@ const buildMockApi = () => ({
   selectedScrollSnap: vi.fn(() => 0),
 })
 
+const mockRef = vi.fn() as unknown as EmblaViewportRefType
+
 beforeEach(() => {
   vi.mocked(useEmblaCarousel).mockReturnValue([
-    vi.fn() as any,
-    buildMockApi() as any,
+    mockRef,
+    buildMockApi() as unknown as EmblaCarouselType,
   ])
 })
 
@@ -93,8 +98,8 @@ describe('TourMediaCarousel', () => {
   it('clicking a dot calls scrollTo', () => {
     const mockApi = buildMockApi()
     vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      mockApi as any,
+      mockRef,
+      mockApi as unknown as EmblaCarouselType,
     ])
     render(<TourMediaCarousel items={imageItems} />)
     const buttons = screen.getAllByRole('button')
@@ -105,8 +110,8 @@ describe('TourMediaCarousel', () => {
   it('clicking previous/next scrolls the carousel', () => {
     const mockApi = buildMockApi()
     vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      mockApi as any,
+      mockRef,
+      mockApi as unknown as EmblaCarouselType,
     ])
     render(<TourMediaCarousel items={imageItems} />)
     const buttons = screen.getAllByRole('button')
@@ -124,10 +129,7 @@ describe('TourMediaCarousel', () => {
   })
 
   it('renders without error when embla api is undefined', () => {
-    vi.mocked(useEmblaCarousel).mockReturnValue([
-      vi.fn() as any,
-      undefined as any,
-    ])
+    vi.mocked(useEmblaCarousel).mockReturnValue([mockRef, undefined])
     render(<TourMediaCarousel items={imageItems} />)
     expect(screen.getByAltText('Image 1')).toBeInTheDocument()
   })

--- a/src/components/ui/__tests__/typography.test.tsx
+++ b/src/components/ui/__tests__/typography.test.tsx
@@ -1,0 +1,18 @@
+import { Title, TitleCard } from '@/components/ui/typography/typography'
+import { render, screen } from '@testing-library/react'
+
+describe('Title', () => {
+  it('renders an h1 with children', () => {
+    render(<Title>Hello World</Title>)
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Hello World' })
+    ).toBeInTheDocument()
+  })
+})
+
+describe('TitleCard', () => {
+  it('renders a paragraph with children', () => {
+    render(<TitleCard>Card Title</TitleCard>)
+    expect(screen.getByText('Card Title')).toBeInTheDocument()
+  })
+})

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -110,6 +110,7 @@ function Carousel({
         api: api,
         opts,
         orientation:
+          /* c8 ignore next */
           orientation || (opts?.axis === 'y' ? 'vertical' : 'horizontal'),
         scrollPrev,
         scrollNext,
@@ -256,6 +257,7 @@ export function MediaCarousel({ items, className }: MediaCarouselProps) {
   )
 
   const onSelect = React.useCallback(() => {
+    /* c8 ignore next */
     if (!emblaApi) return
     setSelectedIndex(emblaApi.selectedScrollSnap())
   }, [emblaApi])

--- a/src/components/ui/tour-media-carousel.tsx
+++ b/src/components/ui/tour-media-carousel.tsx
@@ -34,6 +34,7 @@ export function TourMediaCarousel({
   }, [emblaApi])
 
   const onSelect = React.useCallback(() => {
+    /* c8 ignore next */
     if (!emblaApi) return
     setSelectedIndex(emblaApi.selectedScrollSnap())
     const videos = document.querySelectorAll('video')

--- a/src/lib/__tests__/cloudinary.test.ts
+++ b/src/lib/__tests__/cloudinary.test.ts
@@ -1,0 +1,44 @@
+import { blurDataUrl, imgUrl, videoPoster } from '@/lib/cloudinary'
+
+describe('imgUrl', () => {
+  it('injects f_auto,q_auto into a Cloudinary upload URL', () => {
+    const url = 'https://res.cloudinary.com/demo/image/upload/sample.jpg'
+    expect(imgUrl(url)).toBe(
+      'https://res.cloudinary.com/demo/image/upload/f_auto,q_auto/sample.jpg'
+    )
+  })
+
+  it('returns non-Cloudinary URLs unchanged', () => {
+    const url = 'https://example.com/image.jpg'
+    expect(imgUrl(url)).toBe(url)
+  })
+})
+
+describe('videoPoster', () => {
+  it('generates a jpg poster from an mp4 URL', () => {
+    const url = 'https://res.cloudinary.com/demo/video/upload/sample.mp4'
+    expect(videoPoster(url)).toBe(
+      'https://res.cloudinary.com/demo/video/upload/so_0/sample.jpg'
+    )
+  })
+
+  it('generates a jpg poster from a mov URL', () => {
+    const url = 'https://res.cloudinary.com/demo/video/upload/sample.mov'
+    expect(videoPoster(url)).toBe(
+      'https://res.cloudinary.com/demo/video/upload/so_0/sample.jpg'
+    )
+  })
+
+  it('generates a jpg poster from a webm URL', () => {
+    const url = 'https://res.cloudinary.com/demo/video/upload/sample.webm'
+    expect(videoPoster(url)).toBe(
+      'https://res.cloudinary.com/demo/video/upload/so_0/sample.jpg'
+    )
+  })
+})
+
+describe('blurDataUrl', () => {
+  it('is a valid base64 SVG data URL', () => {
+    expect(blurDataUrl).toMatch(/^data:image\/svg\+xml;base64,/)
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -35,3 +35,7 @@ vi.mock('next/font/local', () => ({
     style: { fontFamily: 'mocked-font' },
   })),
 }))
+
+// jsdom doesn't implement HTMLMediaElement methods
+window.HTMLMediaElement.prototype.pause = vi.fn()
+window.HTMLMediaElement.prototype.play = vi.fn(() => Promise.resolve())

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,13 +8,15 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
-    css: true,
+    css: false,
     typecheck: {
       include: ['**/*.{test,spec}.{ts,tsx}'],
     },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
+      all: true,
+      include: ['src/**/*.{ts,tsx}'],
       exclude: [
         'node_modules/',
         'src/test/',
@@ -23,6 +25,12 @@ export default defineConfig({
         'coverage/',
         '.next/',
       ],
+      thresholds: {
+        branches: 100,
+        functions: 100,
+        lines: 100,
+        statements: 100,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## What and why

The coverage config lacked \`all: true\`, so files with no tests were invisible in the report — only 3 of 31 source files appeared and the "100%" was misleading. This adds 17 new test files to cover every previously untested component and utility, enforces 100% thresholds in \`vitest.config.ts\`, and wires the existing CI job to fail the build automatically when coverage drops.

## Changes

- **vitest.config.ts**: set \`css: false\`, add \`all: true\`, \`include: ['src/**/*.{ts,tsx}']\`, and 100% thresholds for branches/functions/lines/statements
- **src/test/setup.ts**: add global mocks for \`HTMLMediaElement.pause\` and \`play\` (required by jsdom)
- **17 new test files** covering: \`app/page.tsx\`, \`robots.ts\`, \`sitemap.ts\`, \`tours/[name]/page.tsx\`, \`gtm.tsx\`, \`tour-gallery.tsx\`, \`badge.tsx\`, \`card.tsx\`, \`carousel.tsx\`, \`carousel-home.tsx\`, \`carousel-pagination.tsx\`, \`checkbox.tsx\`, \`dropdown-menu.tsx\`, \`select.tsx\`, \`tour-media-carousel.tsx\`, \`typography.tsx\`, \`cloudinary.ts\`
- **src/app/tours/__tests__/tour-detail.test.tsx**: add case for activity without price to cover \`?? 0\` nullish branch
- **carousel.tsx / tour-media-carousel.tsx**: add \`/* c8 ignore next */\` for two genuinely unreachable stale-closure guards (dead code from shadcn template + Embla callback contract)
- **CLAUDE.md**: correct test commands from \`bun test\` → \`bun run test\` and document 100% enforcement

## Type of change

- [x] Chore / refactor (no behaviour change)

## Test plan

- [x] Run \`bun run test:coverage\` — all 125 tests pass, all files report 100% across branches/functions/lines/statements
- [x] Run \`bun run type-check\` — no type errors
- [x] Run \`bun run lint\` — no lint errors
- CI will fail automatically on any PR that drops coverage below 100%

## Notes for reviewer

- Embla carousel \`onSelect\` callbacks have two closure guards (\`if (!emblaApi) return\`) that are unreachable in practice: the outer \`useEffect\` already guards the same condition before calling the callback. These are marked \`/* c8 ignore next */\` rather than removed, to preserve the original shadcn defensive pattern.
- The \`orientation || (opts?.axis...)?\` branch in \`carousel.tsx\` is also dead code (orientation always has the default \`'horizontal'\`) — same treatment.
- The \`next/image\` global mock (returns null) is overridden locally in \`tour-media-carousel.test.tsx\` to render a real \`<img>\` so alt-text assertions work.

---
Linear: https://linear.app/lesteban/issue/LES-124/achieve-100percent-test-coverage-across-all-source-files