### PR TITLE
fix(test): add next/font/google global mock — LES-123

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "roadmapcol",

--- a/src/app/__tests__/layout.test.tsx
+++ b/src/app/__tests__/layout.test.tsx
@@ -1,14 +1,6 @@
 import RootLayout from '@/app/layout'
 import { render } from '@testing-library/react'
 
-vi.mock('next/font/google', () => ({
-  Geist: () => ({ variable: '--font-geist-sans', className: 'geist' }),
-  Geist_Mono: () => ({
-    variable: '--font-geist-mono',
-    className: 'geist-mono',
-  }),
-}))
-
 vi.mock('@vercel/analytics/next', () => ({
   Analytics: () => null,
 }))

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -28,11 +28,22 @@ vi.mock('next/link', () => ({
   ),
 }))
 
-// Mock Next.js font
+// Mock Next.js fonts
 vi.mock('next/font/local', () => ({
   default: vi.fn(() => ({
     className: 'mocked-font-class',
     style: { fontFamily: 'mocked-font' },
+  })),
+}))
+
+vi.mock('next/font/google', () => ({
+  Geist: vi.fn(() => ({
+    className: 'mocked-geist',
+    variable: '--font-geist-sans',
+  })),
+  Geist_Mono: vi.fn(() => ({
+    className: 'mocked-geist-mono',
+    variable: '--font-geist-mono',
   })),
 }))
 


### PR DESCRIPTION
## Summary

- Adds `Geist` and `Geist_Mono` mocks to the global Vitest setup file (`src/test/setup.ts`) so any test that imports `layout.tsx` directly or transitively doesn't need a local override.
- Removes the redundant per-file `next/font/google` mock that was in `layout.test.tsx`.
- All 49 Vitest tests pass (`Test Files 12 passed, Tests 49 passed`).

Closes LES-123.

## Test plan

- [ ] `bunx vitest run` exits with code 0 (49/49 tests pass)
- [ ] `bun test:coverage` exits with code 0 (CI command)

https://claude.ai/code/session_01Lyi5Lp5bBxPaYRx2UWq4wT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lyi5Lp5bBxPaYRx2UWq4wT)_