### PR TITLE
feat(pages): add branded 404 and 500 error pages — LES-82

### DIFF
--- a/src/app/__tests__/error.test.tsx
+++ b/src/app/__tests__/error.test.tsx
@@ -1,0 +1,40 @@
+import ErrorPage from '@/app/error'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+describe('Error', () => {
+  it('renders the error title', () => {
+    render(<ErrorPage error={new Error('boom')} reset={vi.fn()} />)
+    expect(screen.getByText('Oops!')).toBeInTheDocument()
+  })
+
+  it('renders the error message', () => {
+    render(<ErrorPage error={new Error('boom')} reset={vi.fn()} />)
+    expect(
+      screen.getByText(
+        'Something went wrong. Please try again or go back home.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('calls reset when Try again is clicked', async () => {
+    const reset = vi.fn()
+    render(<ErrorPage error={new Error('boom')} reset={reset} />)
+    await userEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(reset).toHaveBeenCalledOnce()
+  })
+
+  it('renders a link to home', () => {
+    render(<ErrorPage error={new Error('boom')} reset={vi.fn()} />)
+    const link = screen.getByRole('link', { name: /go home/i })
+    expect(link).toHaveAttribute('href', '/')
+  })
+
+  it('logs the error to console', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const error = new Error('boom')
+    render(<ErrorPage error={error} reset={vi.fn()} />)
+    expect(spy).toHaveBeenCalledWith(error)
+    spy.mockRestore()
+  })
+})

--- a/src/app/__tests__/not-found.test.tsx
+++ b/src/app/__tests__/not-found.test.tsx
@@ -1,0 +1,24 @@
+import NotFound from '@/app/not-found'
+import { render, screen } from '@testing-library/react'
+
+describe('NotFound', () => {
+  it('renders 404 title', () => {
+    render(<NotFound />)
+    expect(screen.getByText('404')).toBeInTheDocument()
+  })
+
+  it('renders the not found message', () => {
+    render(<NotFound />)
+    expect(
+      screen.getByText(
+        'The page you are looking for does not exist or has been moved.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('renders a link to /tours', () => {
+    render(<NotFound />)
+    const link = screen.getByRole('link', { name: /explore our tours/i })
+    expect(link).toHaveAttribute('href', '/tours')
+  })
+})

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Title } from '@/components/ui/typography/typography'
+import Link from 'next/link'
+import { useEffect } from 'react'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="mx-auto my-14 flex min-h-[calc(100vh-3.5rem)] w-full max-w-7xl flex-col items-center justify-center gap-6 px-4 md:px-8">
+      <Title>Oops!</Title>
+      <p className="max-w-md text-center text-lg text-muted-foreground">
+        Something went wrong. Please try again or go back home.
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <Button size="lg" onClick={reset}>
+          Try again
+        </Button>
+        <Link href="/">
+          <Button size="lg" variant="outline">
+            Go home
+          </Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@/components/ui/button'
+import { Title } from '@/components/ui/typography/typography'
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <div className="mx-auto my-14 flex min-h-[calc(100vh-3.5rem)] w-full max-w-7xl flex-col items-center justify-center gap-6 px-4 md:px-8">
+      <Title>404</Title>
+      <p className="max-w-md text-center text-lg text-muted-foreground">
+        The page you are looking for does not exist or has been moved.
+      </p>
+      <Link href="/tours">
+        <Button size="lg">Explore our tours</Button>
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `src/app/not-found.tsx` — branded 404 page with the `Title` component ("404"), a descriptive message, and a CTA button linking to `/tours`.
- Adds `src/app/error.tsx` — `'use client'` error boundary with a "Try again" button (calls `reset()`) and a "Go home" link. Logs the error via `useEffect`.
- Both pages reuse the Header/Footer from the root layout automatically and follow the existing design system (same container, spacing, and component patterns as other pages).

Closes LES-82.

## Test plan

- [ ] Navigate to a nonexistent URL (e.g. `/does-not-exist`) → see branded 404 page with "Explore our tours" button
- [ ] Trigger a runtime error in a page → see error boundary with "Try again" and "Go home" buttons
- [ ] `bunx vitest run` → 49/49 tests pass

https://claude.ai/code/session_01Lyi5Lp5bBxPaYRx2UWq4wT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lyi5Lp5bBxPaYRx2UWq4wT)_