### PR TITLE
feat(seo): add JSON-LD structured data for Organization and tours — LES-81

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,10 @@
 import { GTM, GTMNoscript } from '@/components/gtm'
+import { JsonLd } from '@/components/json-ld'
 import Footer from '@/components/ui/footer'
 import Header from '@/components/ui/header'
 import { CONTACT } from '@/lib/data'
 import { images } from '@/lib/images'
+import { organizationSchema } from '@/lib/structured-data'
 import { Analytics } from '@vercel/analytics/next'
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
@@ -60,6 +62,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <JsonLd data={organizationSchema()} />
+      </head>
       {isProduction && <GTM />}
       <body
         className={` ${geistSans.variable} ${geistMono.variable} grid min-h-dvh w-full grid-rows-[auto_1fr_auto] antialiased`}

--- a/src/app/tours/[name]/page.tsx
+++ b/src/app/tours/[name]/page.tsx
@@ -1,4 +1,6 @@
+import { JsonLd } from '@/components/json-ld'
 import { TOURS } from '@/lib/data'
+import { breadcrumbSchema, touristTripSchema } from '@/lib/structured-data'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 
@@ -29,5 +31,11 @@ export default async function TourPage({ params }: PageProps) {
     | Tour
     | undefined
   if (!tour) notFound()
-  return <TourClient tour={tour} />
+  return (
+    <>
+      <JsonLd data={touristTripSchema(tour)} />
+      <JsonLd data={breadcrumbSchema(tour.title, tour.href)} />
+      <TourClient tour={tour} />
+    </>
+  )
 }

--- a/src/components/__tests__/json-ld.test.tsx
+++ b/src/components/__tests__/json-ld.test.tsx
@@ -1,0 +1,19 @@
+import { JsonLd } from '@/components/json-ld'
+import { render } from '@testing-library/react'
+
+describe('JsonLd', () => {
+  it('renders a script tag with type application/ld+json', () => {
+    const { container } = render(
+      <JsonLd data={{ '@type': 'Organization', name: 'Test' }} />
+    )
+    const script = container.querySelector('script[type="application/ld+json"]')
+    expect(script).not.toBeNull()
+  })
+
+  it('serialises the data as JSON in the script content', () => {
+    const data = { '@type': 'Organization', name: 'Road Map Col' }
+    const { container } = render(<JsonLd data={data} />)
+    const script = container.querySelector('script[type="application/ld+json"]')
+    expect(script?.innerHTML).toBe(JSON.stringify(data))
+  })
+})

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -1,0 +1,8 @@
+export function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  )
+}

--- a/src/lib/__tests__/structured-data.test.ts
+++ b/src/lib/__tests__/structured-data.test.ts
@@ -1,0 +1,83 @@
+import {
+  breadcrumbSchema,
+  organizationSchema,
+  touristTripSchema,
+} from '@/lib/structured-data'
+
+describe('structured-data', () => {
+  describe('organizationSchema', () => {
+    it('returns Organization schema with correct type and url', () => {
+      const schema = organizationSchema()
+      expect(schema['@type']).toBe('Organization')
+      expect(schema.url).toBe('https://roadmapcol.com')
+      expect(schema.name).toBe('Road Map Col')
+    })
+
+    it('includes contact point with phone and email', () => {
+      const schema = organizationSchema()
+      expect(schema.contactPoint.telephone).toBeDefined()
+      expect(schema.contactPoint.email).toBeDefined()
+    })
+
+    it('includes sameAs with social links', () => {
+      const schema = organizationSchema()
+      expect(Array.isArray(schema.sameAs)).toBe(true)
+      expect(schema.sameAs.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('touristTripSchema', () => {
+    const tour = {
+      description: 'A great tour',
+      href: '/tours/test',
+      image: 'https://example.com/img.jpg',
+      price: 120,
+      title: 'Test Tour',
+    }
+
+    it('returns TouristTrip schema with tour data', () => {
+      const schema = touristTripSchema(tour)
+      expect(schema['@type']).toBe('TouristTrip')
+      expect(schema.name).toBe('Test Tour')
+      expect(schema.description).toBe('A great tour')
+      expect(schema.image).toBe('https://example.com/img.jpg')
+    })
+
+    it('includes offer with correct price and currency', () => {
+      const schema = touristTripSchema(tour)
+      expect(schema.offers.price).toBe(120)
+      expect(schema.offers.priceCurrency).toBe('USD')
+    })
+
+    it('builds full url from href', () => {
+      const schema = touristTripSchema(tour)
+      expect(schema.url).toBe('https://roadmapcol.com/tours/test')
+    })
+  })
+
+  describe('breadcrumbSchema', () => {
+    it('returns BreadcrumbList with 3 items', () => {
+      const schema = breadcrumbSchema('Test Tour', '/tours/test')
+      expect(schema['@type']).toBe('BreadcrumbList')
+      expect(schema.itemListElement).toHaveLength(3)
+    })
+
+    it('sets correct positions and names', () => {
+      const schema = breadcrumbSchema('Test Tour', '/tours/test')
+      const [home, tours, tour] = schema.itemListElement
+      expect(home.position).toBe(1)
+      expect(home.name).toBe('Home')
+      expect(tours.position).toBe(2)
+      expect(tours.name).toBe('Tours')
+      expect(tour.position).toBe(3)
+      expect(tour.name).toBe('Test Tour')
+    })
+
+    it('builds full item urls', () => {
+      const schema = breadcrumbSchema('Test Tour', '/tours/test')
+      expect(schema.itemListElement[2].item).toBe(
+        'https://roadmapcol.com/tours/test'
+      )
+    })
+  })
+})

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,0 +1,73 @@
+import { CONTACT } from './data'
+
+const BASE_URL = 'https://roadmapcol.com'
+const LOGO_URL =
+  'https://res.cloudinary.com/lesteban/image/upload/v1748229585/roadmap/road_map_sin_fondo_atjeji.png'
+
+export function organizationSchema() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    contactPoint: {
+      '@type': 'ContactPoint',
+      contactType: 'customer support',
+      email: CONTACT.email,
+      telephone: CONTACT.phone,
+    },
+    logo: LOGO_URL,
+    name: 'Road Map Col',
+    sameAs: [CONTACT.instagram, CONTACT.tiktok],
+    url: BASE_URL,
+  }
+}
+
+export function touristTripSchema(tour: {
+  description: string
+  href: string
+  image: string
+  price: number
+  title: string
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'TouristTrip',
+    description: tour.description,
+    image: tour.image,
+    name: tour.title,
+    offers: {
+      '@type': 'Offer',
+      availability: 'https://schema.org/InStock',
+      price: tour.price,
+      priceCurrency: 'USD',
+      url: `${BASE_URL}${tour.href}`,
+    },
+    url: `${BASE_URL}${tour.href}`,
+  }
+}
+
+export function breadcrumbSchema(tourTitle: string, tourHref: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        item: BASE_URL,
+        name: 'Home',
+        position: 1,
+      },
+      {
+        '@type': 'ListItem',
+        item: `${BASE_URL}/tours`,
+        name: 'Tours',
+        position: 2,
+      },
+      {
+        '@type': 'ListItem',
+        item: `${BASE_URL}${tourHref}`,
+        name: tourTitle,
+        position: 3,
+      },
+    ],
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/structured-data.ts` — three pure schema generators (`organizationSchema`, `touristTripSchema`, `breadcrumbSchema`).
- Adds `src/components/json-ld.tsx` — lightweight server component that injects `<script type="application/ld+json">`.
- Injects **Organization** schema in the root `<head>` via `layout.tsx` (name, url, logo, contactPoint, sameAs for Instagram and TikTok).
- Injects **TouristTrip** + **BreadcrumbList** schemas on every tour detail page (`/tours/[name]`) as server-rendered script tags.

Closes LES-81.

## Test plan

- [ ] `bunx vitest run --coverage` — 136/136 tests pass, 100% coverage maintained
- [ ] Open any tour page and inspect the HTML source → two `<script type="application/ld+json">` blocks (TouristTrip + BreadcrumbList)
- [ ] Inspect root layout HTML source → one `<script type="application/ld+json">` block (Organization) inside `<head>`
- [ ] Validate with [Google Rich Results Test](https://search.google.com/test/rich-results)

https://claude.ai/code/session_01Lyi5Lp5bBxPaYRx2UWq4wT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lyi5Lp5bBxPaYRx2UWq4wT)_