### PR TITLE
feat: Move GTM container ID to environment variable (LES-77)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_GTM_ID=your_gtm_container_id

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/src/components/gtm.tsx
+++ b/src/components/gtm.tsx
@@ -4,8 +4,6 @@ import { usePathname, useSearchParams } from 'next/navigation'
 import Script from 'next/script'
 import { Suspense, useEffect } from 'react'
 
-const GTM_ID = 'GTM-N2ZVJPC2'
-
 function GTMPageView() {
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -14,7 +12,9 @@ function GTMPageView() {
     if (pathname) {
       window.dataLayer?.push({
         event: 'pageview',
-        page: pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : ''),
+        page:
+          pathname +
+          (searchParams?.toString() ? `?${searchParams.toString()}` : ''),
       })
     }
   }, [pathname, searchParams])
@@ -34,7 +34,7 @@ export function GTM() {
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','${GTM_ID}');
+            })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_ID}');
           `,
         }}
       />
@@ -49,7 +49,7 @@ export function GTMNoscript() {
   return (
     <noscript>
       <iframe
-        src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
+        src={`https://www.googletagmanager.com/ns.html?id=${process.env.NEXT_PUBLIC_GTM_ID}`}
         height="0"
         width="0"
         style={{ display: 'none', visibility: 'hidden' }}


### PR DESCRIPTION
## What and why
The GTM container ID \`GTM-N2ZVJPC2\` was hardcoded in the GTM component, making it impossible to use different containers per environment (staging vs production) without a code change. This moves it to a \`NEXT_PUBLIC_GTM_ID\` env var so each environment can be configured independently.

## Changes
- Removed hardcoded \`GTM_ID\` constant from \`src/components/gtm.tsx\`; replaced both usages with \`process.env.NEXT_PUBLIC_GTM_ID\`
- Added \`.env.example\` documenting the required variable (committed; \`.env.local\` stays gitignored)
- Added \`!.env.example\` exception to \`.gitignore\` so the example file is tracked
- Added \`NEXT_PUBLIC_GTM_ID=GTM-N2ZVJPC2\` to Vercel for production, preview, and development environments

## Type of change
- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Chore / refactor (no behaviour change)
- [ ] Breaking change (existing functionality is affected)

## Test plan
- [x] Run `bun test` — all 144 tests pass
- [x] Run `bun run type-check` — no type errors
- [x] Run `bun run lint` — no new errors
- [ ] Verify GTM fires correctly in production after deploy (container ID visible in network requests to `googletagmanager.com`)

## Notes for reviewer
`.env.local` is gitignored and must be created locally with `NEXT_PUBLIC_GTM_ID=GTM-N2ZVJPC2`. The `.env.example` file documents this. Vercel environments already have the variable set via CLI.

---
Linear: https://linear.app/lesteban/issue/LES-77/move-gtm-id-to-environment-variable