### PR TITLE
feat(security): add HTTP security headers — LES-76

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,31 @@
 import type { NextConfig } from 'next'
 
+const securityHeaders = [
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+]
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [{ headers: securityHeaders, source: '/(.*)', }]
+  },
   images: {
     remotePatterns: [
       {
-        protocol: 'https',
         hostname: 'res.cloudinary.com',
+        protocol: 'https',
       },
     ],
   },


### PR DESCRIPTION
## Summary

Adds the following HTTP security headers to **all routes** via the `headers()` function in `next.config.ts`:

| Header | Value |
|--------|-------|
| `X-Frame-Options` | `DENY` — prevents clickjacking |
| `X-Content-Type-Options` | `nosniff` — prevents MIME sniffing |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` |

Closes LES-76.

## Test plan

- [ ] `bunx vitest run --coverage` — 125/125 tests pass (config files excluded from coverage)
- [ ] `bun run build && bun start` — check response headers with `curl -I http://localhost:3000` and confirm all five headers are present

https://claude.ai/code/session_01Lyi5Lp5bBxPaYRx2UWq4wT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lyi5Lp5bBxPaYRx2UWq4wT)_