### PR TITLE
feat: add SEO-driven travel blog with 17 launch articles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "roadmapcol",
@@ -15,12 +16,17 @@
         "clsx": "2.1.1",
         "embla-carousel-autoplay": "8.6.0",
         "embla-carousel-react": "8.6.0",
+        "gray-matter": "4.0.3",
         "lucide-react": "0.511.0",
         "next": "16.2.6",
         "prettier-plugin-tailwindcss": "0.6.12",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-type-animation": "3.2.0",
+        "reading-time": "1.5.0",
+        "remark": "15.0.1",
+        "remark-gfm": "4.0.1",
+        "remark-html": "16.0.1",
         "tailwind-merge": "3.3.0",
       },
       "devDependencies": {
@@ -452,17 +458,27 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.20.7", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
+
+    "@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@20.17.47", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-3dLX0Upo1v7RvUimvxLeXqwrfyKxUINk0EAM83swP2mlSUcwV73sZy8XhNz8bcZ3VbsfQyC/y6jRdL5tgCNpDQ=="],
 
     "@types/react": ["@types/react@19.1.4", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-EB1yiiYdvySuIITtD5lhW4yPyJ31RkJkkDw794LaQYrxCSaQV/47y5o1FMC4zF9ZyjUjzJMZwbovEnT5yHTW6g=="],
 
     "@types/react-dom": ["@types/react-dom@19.1.5", "", { "peerDependencies": { "@types/react": "^19.0.0" } }, "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.59.3", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.59.3", "@typescript-eslint/type-utils": "8.59.3", "@typescript-eslint/utils": "8.59.3", "@typescript-eslint/visitor-keys": "8.59.3", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.59.3", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw=="],
 
@@ -483,6 +499,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.59.3", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.59.3", "@typescript-eslint/types": "8.59.3", "@typescript-eslint/typescript-estree": "8.59.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.59.3", "", { "dependencies": { "@typescript-eslint/types": "8.59.3", "eslint-visitor-keys": "^5.0.0" } }, "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
 
     "@unrs/resolver-binding-darwin-arm64": ["@unrs/resolver-binding-darwin-arm64@1.7.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vxtBno4xvowwNmO/ASL0Y45TpHqmNkAaDtz4Jqb+clmcVSSl8XCG/PNFFkGsXXXS6AMjP+ja/TtNCFFa1QwLRg=="],
 
@@ -588,6 +606,8 @@
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.29", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ=="],
@@ -610,9 +630,17 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001726", "", {}, "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "chai": ["chai@5.2.0", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw=="],
 
     "chalk": ["chalk@3.0.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "check-error": ["check-error@2.1.1", "", {}, "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw=="],
 
@@ -629,6 +657,8 @@
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -656,6 +686,8 @@
 
     "decimal.js": ["decimal.js@10.5.0", "", {}, "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
@@ -671,6 +703,8 @@
     "detect-libc": ["detect-libc@2.0.4", "", {}, "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
@@ -744,6 +778,8 @@
 
     "espree": ["espree@10.3.0", "", { "dependencies": { "acorn": "^8.14.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.0" } }, "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg=="],
 
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
     "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
@@ -755,6 +791,10 @@
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "expect-type": ["expect-type@1.2.1", "", {}, "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -818,6 +858,8 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -832,6 +874,12 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
@@ -839,6 +887,8 @@
     "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
@@ -874,6 +924,8 @@
 
     "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
 
+    "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
@@ -891,6 +943,8 @@
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
@@ -952,6 +1006,8 @@
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
+    "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
 
     "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
@@ -986,6 +1042,8 @@
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": "cli.js" }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "loupe": ["loupe@3.1.4", "", {}, "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg=="],
@@ -1002,9 +1060,91 @@
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
@@ -1100,6 +1240,8 @@
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
@@ -1120,11 +1262,23 @@
 
     "react-type-animation": ["react-type-animation@3.2.0", "", { "peerDependencies": { "prop-types": "^15.5.4", "react": ">= 15.0.0", "react-dom": ">= 15.0.0" } }, "sha512-WXTe0i3rRNKjmggPvT5ntye1QBt0ATGbijeW6V3cQe2W0jaMABXXlPPEdtofnS9tM7wSRHchEvI9SUw+0kUohw=="],
 
+    "reading-time": ["reading-time@1.5.0", "", {}, "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg=="],
+
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
+
+    "remark": ["remark@15.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-html": ["remark-html@16.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "hast-util-sanitize": "^5.0.0", "hast-util-to-html": "^9.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0" } }, "sha512-B9JqA5i0qZe0Nsf49q3OXyGvyXuZFDzAP2iOFLEumymuYJITVpiH1IgsTEwTpdptDmZlMDMWeDmSawdaJIGCXQ=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": "bin/resolve" }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 
@@ -1151,6 +1305,8 @@
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.25.0", "", {}, "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA=="],
+
+    "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
     "semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1182,6 +1338,10 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
@@ -1206,11 +1366,15 @@
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
 
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
+
+    "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
@@ -1258,6 +1422,10 @@
 
     "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg=="],
@@ -1284,6 +1452,18 @@
 
     "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
 
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "unrs-resolver": ["unrs-resolver@1.7.2", "", { "dependencies": { "napi-postinstall": "^0.2.2" }, "optionalDependencies": { "@unrs/resolver-binding-darwin-arm64": "1.7.2", "@unrs/resolver-binding-darwin-x64": "1.7.2", "@unrs/resolver-binding-freebsd-x64": "1.7.2", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.7.2", "@unrs/resolver-binding-linux-arm-musleabihf": "1.7.2", "@unrs/resolver-binding-linux-arm64-gnu": "1.7.2", "@unrs/resolver-binding-linux-arm64-musl": "1.7.2", "@unrs/resolver-binding-linux-ppc64-gnu": "1.7.2", "@unrs/resolver-binding-linux-riscv64-gnu": "1.7.2", "@unrs/resolver-binding-linux-riscv64-musl": "1.7.2", "@unrs/resolver-binding-linux-s390x-gnu": "1.7.2", "@unrs/resolver-binding-linux-x64-gnu": "1.7.2", "@unrs/resolver-binding-linux-x64-musl": "1.7.2", "@unrs/resolver-binding-wasm32-wasi": "1.7.2", "@unrs/resolver-binding-win32-arm64-msvc": "1.7.2", "@unrs/resolver-binding-win32-ia32-msvc": "1.7.2", "@unrs/resolver-binding-win32-x64-msvc": "1.7.2" } }, "sha512-BBKpaylOW8KbHsu378Zky/dGh4ckT/4NW/0SHRABdqRLcQJ2dAOjDo9g97p04sWflm0kqPqpUatxReNV/dqI5A=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
@@ -1293,6 +1473,10 @@
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-sidecar": ["use-sidecar@1.1.3", "", { "dependencies": { "detect-node-es": "^1.1.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@5.4.19", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA=="],
 
@@ -1341,6 +1525,8 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -1450,6 +1636,8 @@
 
     "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
+    "gray-matter/js-yaml": ["js-yaml@3.15.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag=="],
+
     "is-bun-module/semver": ["semver@7.7.2", "", { "bin": "bin/semver.js" }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "jsx-ast-utils/array-includes": ["array-includes@3.1.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.2", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.4", "is-string": "^1.0.7" } }, "sha512-itaWrbYbqpGXkGhZPGUulwnhVf5Hpy1xiCFsGqyIGglbBxmG5vSjxQen3/WGOjPpNEv1RtBLKxbmVXm8HpJStQ=="],
@@ -1461,6 +1649,10 @@
     "magicast/@babel/types": ["@babel/types@7.27.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw=="],
 
     "make-dir/semver": ["semver@7.7.2", "", { "bin": "bin/semver.js" }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "micromark/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -1539,6 +1731,8 @@
     "eslint-plugin-react/array-includes/es-abstract": ["es-abstract@1.23.9", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.3", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.0", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-regex": "^1.2.1", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.0", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.3", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.3", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.18" } }, "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "jsx-ast-utils/array-includes/es-abstract": ["es-abstract@1.23.9", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.3", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.0", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-regex": "^1.2.1", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.0", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.3", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.3", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.18" } }, "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA=="],
 

--- a/package.json
+++ b/package.json
@@ -26,12 +26,17 @@
     "clsx": "2.1.1",
     "embla-carousel-autoplay": "8.6.0",
     "embla-carousel-react": "8.6.0",
+    "gray-matter": "4.0.3",
     "lucide-react": "0.511.0",
     "next": "16.2.6",
     "prettier-plugin-tailwindcss": "0.6.12",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-type-animation": "3.2.0",
+    "reading-time": "1.5.0",
+    "remark": "15.0.1",
+    "remark-gfm": "4.0.1",
+    "remark-html": "16.0.1",
     "tailwind-merge": "3.3.0"
   },
   "devDependencies": {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,76 @@
+import { JsonLd } from '@/components/json-ld'
+import { Button } from '@/components/ui/button'
+import { Title } from '@/components/ui/typography/typography'
+import { getAllPostSlugs, getPostBySlug } from '@/lib/blog'
+import { renderMarkdown } from '@/lib/markdown'
+import { blogBreadcrumbSchema, blogPostingSchema } from '@/lib/structured-data'
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+export function generateStaticParams() {
+  return getAllPostSlugs().map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const post = getPostBySlug(slug)
+  if (!post) return {}
+  return {
+    alternates: { canonical: `/blog/${post.slug}` },
+    description: post.description,
+    openGraph: { images: [{ alt: post.title, url: post.coverImage }] },
+    title: post.title,
+  }
+}
+
+export default async function BlogPostPage({ params }: PageProps) {
+  const { slug } = await params
+  const post = getPostBySlug(slug)
+  if (!post) notFound()
+  const html = await renderMarkdown(post.content)
+
+  return (
+    <article className="mx-auto my-14 flex w-full max-w-3xl flex-col gap-6 px-4 md:px-8">
+      <JsonLd data={blogPostingSchema(post)} />
+      <JsonLd data={blogBreadcrumbSchema(post.title, post.slug)} />
+      <div className="relative h-64 w-full overflow-hidden rounded-md md:h-96">
+        <Image
+          src={post.coverImage}
+          alt={post.title}
+          fill
+          priority
+          className="object-cover"
+        />
+      </div>
+      <Title>{post.title}</Title>
+      <p className="text-muted-foreground -mt-4 text-center text-sm">
+        {new Date(post.date).toLocaleDateString('en-US', {
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric',
+        })}{' '}
+        · {post.readingTime}
+      </p>
+      <div
+        className="blog-content mx-auto w-full"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      <div className="bg-muted flex flex-col items-center gap-4 rounded-md p-6 text-center">
+        <p className="font-semibold">
+          Ready to experience it for yourself in Colombia?
+        </p>
+        <Link href={post.relatedTourHref ?? '/tours'}>
+          <Button>See our tours</Button>
+        </Link>
+      </div>
+    </article>
+  )
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { JsonLd } from '@/components/json-ld'
 import { Button } from '@/components/ui/button'
-import { Title } from '@/components/ui/typography/typography'
+import { PostTitle } from '@/components/ui/typography/typography'
 import { getAllPostSlugs, getPostBySlug } from '@/lib/blog'
 import { renderMarkdown } from '@/lib/markdown'
 import { blogBreadcrumbSchema, blogPostingSchema } from '@/lib/structured-data'
@@ -50,8 +50,8 @@ export default async function BlogPostPage({ params }: PageProps) {
           className="object-cover"
         />
       </div>
-      <Title>{post.title}</Title>
-      <p className="text-muted-foreground -mt-4 text-center text-sm">
+      <PostTitle>{post.title}</PostTitle>
+      <p className="text-muted-foreground text-center text-sm">
         {new Date(post.date).toLocaleDateString('en-US', {
           day: 'numeric',
           month: 'long',

--- a/src/app/blog/__tests__/blog-index.test.tsx
+++ b/src/app/blog/__tests__/blog-index.test.tsx
@@ -1,0 +1,54 @@
+import BlogIndex from '@/app/blog/page'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('next/image', () => ({
+  default: (props: { alt: string; src: string }) => (
+    <img alt={props.alt} src={props.src} />
+  ),
+}))
+
+vi.mock('@/lib/blog', () => ({
+  getAllPosts: () => [
+    {
+      coverImage: 'https://example.com/a.jpg',
+      date: '2026-01-01',
+      description: 'Description A',
+      readingTime: '3 min read',
+      slug: 'post-a',
+      tags: ['guide'],
+      title: 'Post A',
+    },
+    {
+      coverImage: 'https://example.com/b.jpg',
+      date: '2026-01-02',
+      description: 'Description B',
+      readingTime: '5 min read',
+      slug: 'post-b',
+      tags: ['guide'],
+      title: 'Post B',
+    },
+  ],
+}))
+
+describe('Blog index page', () => {
+  it('renders the page title', () => {
+    render(<BlogIndex />)
+    expect(screen.getByText('Travel Blog')).toBeInTheDocument()
+  })
+
+  it('renders a card for every post with a link to its detail page', () => {
+    render(<BlogIndex />)
+    expect(screen.getByText('Post A')).toBeInTheDocument()
+    expect(screen.getByText('Post B')).toBeInTheDocument()
+    expect(screen.getByText('Post A').closest('a')).toHaveAttribute(
+      'href',
+      '/blog/post-a'
+    )
+  })
+
+  it('renders each post description and reading time', () => {
+    render(<BlogIndex />)
+    expect(screen.getByText('Description A')).toBeInTheDocument()
+    expect(screen.getByText('3 min read')).toBeInTheDocument()
+  })
+})

--- a/src/app/blog/__tests__/blog-post.test.tsx
+++ b/src/app/blog/__tests__/blog-post.test.tsx
@@ -1,0 +1,114 @@
+import BlogPostPage, {
+  generateMetadata,
+  generateStaticParams,
+} from '@/app/blog/[slug]/page'
+import { render, screen } from '@testing-library/react'
+import { notFound } from 'next/navigation'
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND')
+  }),
+}))
+
+vi.mock('@/lib/markdown', () => ({
+  renderMarkdown: async (content: string) => `<p>${content}</p>`,
+}))
+
+const posts = {
+  'post-a': {
+    content: 'Hello world content',
+    coverImage: 'https://example.com/a.jpg',
+    date: '2026-01-01',
+    description: 'Description A',
+    readingTime: '3 min read',
+    relatedTourHref: '/tours/guatape',
+    slug: 'post-a',
+    tags: ['guide'],
+    title: 'Post A',
+  },
+  'post-b': {
+    content: 'More content',
+    coverImage: 'https://example.com/b.jpg',
+    date: '2026-01-02',
+    description: 'Description B',
+    readingTime: '5 min read',
+    slug: 'post-b',
+    tags: ['guide'],
+    title: 'Post B',
+  },
+}
+
+vi.mock('@/lib/blog', () => ({
+  getAllPostSlugs: () => Object.keys(posts),
+  getPostBySlug: (slug: string) => posts[slug as keyof typeof posts] ?? null,
+}))
+
+describe('generateStaticParams', () => {
+  it('returns params for every slug', () => {
+    expect(generateStaticParams()).toEqual([
+      { slug: 'post-a' },
+      { slug: 'post-b' },
+    ])
+  })
+})
+
+describe('generateMetadata', () => {
+  it('returns metadata for a known post', async () => {
+    const result = await generateMetadata({
+      params: Promise.resolve({ slug: 'post-a' }),
+    })
+    expect(result.title).toBe('Post A')
+    expect(result.description).toBe('Description A')
+    expect(result.alternates?.canonical).toBe('/blog/post-a')
+  })
+
+  it('returns empty object for an unknown post', async () => {
+    const result = await generateMetadata({
+      params: Promise.resolve({ slug: 'unknown' }),
+    })
+    expect(result).toEqual({})
+  })
+})
+
+describe('BlogPostPage', () => {
+  it('renders the post title and rendered markdown content for a known slug', async () => {
+    const element = await BlogPostPage({
+      params: Promise.resolve({ slug: 'post-a' }),
+    })
+    const { container } = render(element)
+    expect(screen.getByText('Post A')).toBeInTheDocument()
+    expect(container.querySelector('.blog-content')).toHaveTextContent(
+      'Hello world content'
+    )
+  })
+
+  it('links the CTA to the related tour when present', async () => {
+    const element = await BlogPostPage({
+      params: Promise.resolve({ slug: 'post-a' }),
+    })
+    render(element)
+    expect(screen.getByText('See our tours').closest('a')).toHaveAttribute(
+      'href',
+      '/tours/guatape'
+    )
+  })
+
+  it('falls back to /tours when there is no related tour', async () => {
+    const element = await BlogPostPage({
+      params: Promise.resolve({ slug: 'post-b' }),
+    })
+    render(element)
+    expect(screen.getByText('See our tours').closest('a')).toHaveAttribute(
+      'href',
+      '/tours'
+    )
+  })
+
+  it('calls notFound for an unknown slug', async () => {
+    await expect(
+      BlogPostPage({ params: Promise.resolve({ slug: 'unknown' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND')
+    expect(notFound).toHaveBeenCalled()
+  })
+})

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,63 @@
+import { JsonLd } from '@/components/json-ld'
+import { Title } from '@/components/ui/typography/typography'
+import { getAllPosts } from '@/lib/blog'
+import { itemListSchema } from '@/lib/structured-data'
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+
+export const metadata: Metadata = {
+  alternates: { canonical: '/blog' },
+  description:
+    'Travel guides, tips and stories about Medellín, Antioquia and Colombia — safety, itineraries, food, and our favorite day trips.',
+  title: 'Travel Blog',
+}
+
+export default function BlogIndex() {
+  const posts = getAllPosts()
+
+  return (
+    <div className="mx-auto my-14 flex min-h-[calc(100vh-3.5rem)] w-full max-w-7xl flex-col items-center justify-start gap-6 px-4 md:px-8">
+      <JsonLd
+        data={itemListSchema(
+          posts.map((post) => ({
+            href: `/blog/${post.slug}`,
+            title: post.title,
+          }))
+        )}
+      />
+      <Title>Travel Blog</Title>
+      <p className="text-muted-foreground max-w-xl text-center">
+        Guides, tips and stories to help you plan the perfect trip to Medellín,
+        Antioquia and Colombia.
+      </p>
+      <div className="grid w-full grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {posts.map((post) => (
+          <Link
+            key={post.slug}
+            href={`/blog/${post.slug}`}
+            className="group flex flex-col overflow-hidden rounded-md border"
+          >
+            <div className="relative h-48 w-full overflow-hidden">
+              <Image
+                src={post.coverImage}
+                alt={post.title}
+                fill
+                className="object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+            </div>
+            <div className="flex flex-1 flex-col gap-2 p-4">
+              <h2 className="text-lg font-bold">{post.title}</h2>
+              <p className="text-muted-foreground line-clamp-3 text-sm">
+                {post.description}
+              </p>
+              <span className="text-muted-foreground mt-auto text-xs">
+                {post.readingTime}
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -125,3 +125,52 @@
 * {
   scroll-behavior: smooth;
 }
+
+.blog-content h2 {
+  @apply mt-10 mb-4 text-2xl font-bold md:text-3xl;
+}
+
+.blog-content h3 {
+  @apply mt-8 mb-3 text-xl font-bold;
+}
+
+.blog-content p {
+  @apply text-foreground mb-5 leading-relaxed;
+}
+
+.blog-content a {
+  @apply text-primary font-medium underline underline-offset-4 hover:no-underline;
+}
+
+.blog-content strong {
+  @apply font-semibold;
+}
+
+.blog-content ul {
+  @apply my-4 list-disc space-y-2 pl-6;
+}
+
+.blog-content ol {
+  @apply my-4 list-decimal space-y-2 pl-6;
+}
+
+.blog-content li {
+  @apply leading-relaxed;
+}
+
+.blog-content blockquote {
+  @apply border-primary text-muted-foreground my-6 border-l-4 pl-4 italic;
+}
+
+.blog-content table {
+  @apply my-6 w-full border-collapse text-left text-sm;
+}
+
+.blog-content th,
+.blog-content td {
+  @apply border-border border px-3 py-2;
+}
+
+.blog-content th {
+  @apply bg-muted font-semibold;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,3 +1,4 @@
+import { getAllPostSlugs } from '@/lib/blog'
 import { TOURS } from '@/lib/data'
 import { MetadataRoute } from 'next'
 
@@ -20,6 +21,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
       url: `${BASE_URL}/personalize`,
     },
+    {
+      changeFrequency: 'weekly',
+      lastModified,
+      priority: 0.7,
+      url: `${BASE_URL}/blog`,
+    },
   ]
 
   const uniqueTourHrefs = [...new Set(TOURS.map((tour) => tour.href))]
@@ -30,5 +37,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     url: `${BASE_URL}${href}`,
   }))
 
-  return [...staticRoutes, ...tourRoutes]
+  const blogRoutes: MetadataRoute.Sitemap = getAllPostSlugs().map((slug) => ({
+    changeFrequency: 'monthly',
+    lastModified,
+    priority: 0.6,
+    url: `${BASE_URL}/blog/${slug}`,
+  }))
+
+  return [...staticRoutes, ...tourRoutes, ...blogRoutes]
 }

--- a/src/components/ui/__tests__/typography.test.tsx
+++ b/src/components/ui/__tests__/typography.test.tsx
@@ -1,4 +1,8 @@
-import { Title, TitleCard } from '@/components/ui/typography/typography'
+import {
+  PostTitle,
+  Title,
+  TitleCard,
+} from '@/components/ui/typography/typography'
 import { render, screen } from '@testing-library/react'
 
 describe('Title', () => {
@@ -6,6 +10,15 @@ describe('Title', () => {
     render(<Title>Hello World</Title>)
     expect(
       screen.getByRole('heading', { level: 1, name: 'Hello World' })
+    ).toBeInTheDocument()
+  })
+})
+
+describe('PostTitle', () => {
+  it('renders an h1 with children', () => {
+    render(<PostTitle>A Long Blog Post Title</PostTitle>)
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'A Long Blog Post Title' })
     ).toBeInTheDocument()
   })
 })

--- a/src/components/ui/typography/typography.tsx
+++ b/src/components/ui/typography/typography.tsx
@@ -12,6 +12,12 @@ export function Title({ children }: { children: React.ReactNode }) {
   )
 }
 
+export function PostTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <h1 className="text-center text-3xl font-bold md:text-5xl">{children}</h1>
+  )
+}
+
 export function TitleCard({ children }: { children: React.ReactNode }) {
   return (
     <p className={`text-6xl text-black text-shadow-lg ${oneBrush.className}`}>

--- a/src/content/blog/best-day-trips-from-medellin.md
+++ b/src/content/blog/best-day-trips-from-medellin.md
@@ -1,0 +1,52 @@
+---
+title: "8 Best Day Trips from Medellín (And How to Choose One)"
+description: "A comparison of the best day trips from Medellín — Guatapé, Jardín, Hacienda Nápoles and more — to help you decide which fits your schedule and interests."
+date: "2026-07-04"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1749944601/roadmapcol/oriente/oriente-4_kfqzde.jpg"
+tags:
+  ["day trips from medellin", "antioquia excursions", "medellin travel guide"]
+relatedTourHref: "/tours"
+---
+
+Medellín's biggest advantage as a travel base isn't just the city itself — it's everything within a few hours' drive. Antioquia packs an unusual amount of variety into a relatively small area: reservoirs, coffee pueblos, adventure sports, and even a former drug lord's private zoo. Here's how the main options compare.
+
+## 1. Guatapé and El Peñol
+
+The classic, and for good reason — a colorful lakeside town plus a 700-step climb up a granite monolith with sweeping reservoir views. Best for first-time visitors who want the single most iconic Antioquia day trip. See our [Guatapé tour](/tours/guatape).
+
+## 2. Comuna 13
+
+Technically inside Medellín rather than a trip out of the city, but functions like a half-day excursion — outdoor escalators, street art, and one of the clearest windows into the city's transformation. Best paired with other city sightseeing. See our [Comuna 13 tour](/tours/comuna13).
+
+## 3. Jardín
+
+A coffee-country pueblo with a genuine waterfall-in-a-cave hike (Cueva del Esplendor) and some of the best small-town atmosphere in Antioquia. Best for travelers who want pueblo charm plus real hiking. See our [Jardín tour](/tours/jardin).
+
+## 4. Hacienda Nápoles
+
+Pablo Escobar's former estate, now a theme park with a water park, zoo, and museums, plus Rio Claro canyon nearby for hiking and rafting. The longest day trip on this list — best for travelers with a full day (or two) to spare. See our [Hacienda Nápoles tour](/tours/hacienda-napoles).
+
+## 5. El Salto del Buey (La Ceja)
+
+A waterfall hike combined with a high-altitude canopy zip-line circuit, plus optional via ferrata climbing and hanging hammocks over the canyon. Best for adventure-focused travelers, with enough variety for mixed groups. See our [Salto del Buey tour](/tours/salto-del-buey).
+
+## 6. Paragliding over Medellín
+
+Not a full day trip in the traditional sense, but a short excursion into the hills above the city for a tandem paragliding flight. Best as a half-day add-on to another activity. See our [paragliding experience](/tours/paragliding).
+
+## 7. The Oriente Antioqueño (Orient Tour)
+
+Less about a single landmark, more about the local tradition of "puebliar" — pueblo-hopping through the eastern highlands for food, coffee, and small-town plazas. Best for travelers who've already done the bigger-name trips and want something more local. See our [Orient Tour](/tours/orient-tour).
+
+## 8. Rio Claro Canyon
+
+Usually paired with Hacienda Nápoles given the shared route, Rio Claro offers marble-walled river canyons, caves, and rafting — a strong nature-and-adventure complement to the theme park.
+
+## How to choose
+
+- **Short on time?** Guatapé or Comuna 13 fit comfortably into a single day without feeling rushed.
+- **Want adventure?** Salto del Buey or paragliding.
+- **Want something slower and local?** Jardín or the Oriente.
+- **Have extra time?** Hacienda Nápoles and Rio Claro combine well across a longer visit.
+
+Whichever you choose, avoid stacking two full day trips back to back — each of these destinations is worth its own unrushed day. Browse [all of our tours](/tours) to start building your Antioquia itinerary.

--- a/src/content/blog/best-time-to-visit-medellin-antioquia.md
+++ b/src/content/blog/best-time-to-visit-medellin-antioquia.md
@@ -1,0 +1,39 @@
+---
+title: "Best Time to Visit Medellín and Antioquia: A Season-by-Season Guide"
+description: "Medellín's climate barely changes year-round, so timing your trip is more about rain patterns, festivals and crowds than temperature. Here's how to plan."
+date: "2026-06-10"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/w_1920,q_auto,f_auto/v1748743344/roadmap/colombian-landscape_obm8nb.avif"
+tags: ["best time to visit medellin", "colombia weather", "travel planning"]
+---
+
+Medellín is nicknamed the "City of Eternal Spring" for a reason: sitting in a valley at around 1,500 meters of elevation, close to the equator, it holds a fairly narrow temperature range year-round — generally somewhere in the low-to-high 20s Celsius, day after day, month after month. That simplifies trip planning a lot, but it doesn't mean every month is identical.
+
+## Temperature isn't really the variable — rain is
+
+Because Medellín's temperature barely shifts across the year, the real planning question is rainfall, not heat or cold. Antioquia has two rainier stretches (roughly April–May and October–November) and two drier stretches (roughly December–March and July–August), though these patterns vary year to year and shouldn't be treated as a guarantee.
+
+## Drier months: December–March and July–August
+
+These stretches tend to be the most popular with visitors, for good reason — outdoor activities like hiking, paragliding, and day trips to Guatapé or Jardín are more pleasant without regular afternoon downpours. December in particular sees Medellín's famous holiday lights displays (Alumbrados), which draw large domestic crowds alongside international visitors.
+
+## Rainier months: April–May and October–November
+
+Rain in Medellín is usually a heavy afternoon downpour rather than an all-day event, so these months aren't a reason to avoid visiting — they're simply a reason to plan outdoor activities for the morning and build in some flexibility. Rates and crowds also tend to ease slightly during these windows.
+
+## Festival timing worth planning around
+
+- **Feria de las Flores (Flower Festival)**, typically early August — one of Medellín's biggest cultural events, built around the region's flower-growing tradition, with the _Desfile de Silleteros_ as its centerpiece.
+- **Alumbrados**, the city's Christmas lights, generally running from late November or early December through early January.
+- **Various coffee and agricultural festivals** in pueblos like Jardín, tied to local harvest cycles rather than a fixed citywide calendar.
+
+If a specific festival is a priority, it's worth checking current dates before booking, since exact timing can shift year to year.
+
+## What this means for day trips
+
+Because Guatapé, Jardín, Comuna 13, and most of the region's other highlights are outdoor or partially outdoor experiences, the drier months generally make for a more predictable day. That said, Antioquia's mountain weather can change quickly regardless of season — packing a light rain layer is good practice on any day trip, any time of year.
+
+## The short version
+
+There isn't really a bad time to visit Medellín — the eternal-spring climate means you're unlikely to face extreme heat or cold whenever you go. If your itinerary is packed with outdoor day trips, lean toward December–March or July–August. If flexibility isn't an issue and you'd rather avoid peak crowds, the shoulder months work just as well with a bit more rain tolerance.
+
+Whenever you're planning to come, browse our [full range of tours](/tours) to build an itinerary around the season you're visiting in.

--- a/src/content/blog/colombia-packing-list-antioquia.md
+++ b/src/content/blog/colombia-packing-list-antioquia.md
@@ -1,0 +1,43 @@
+---
+title: "What to Pack for Colombia: A Complete Packing List for Antioquia"
+description: "A practical packing list for a trip to Medellín and Antioquia, covering the region's mild climate, mountain day trips, and rainy-season essentials."
+date: "2026-06-26"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1749945189/roadmapcol/jardin/jardin-2_t1szg1.jpg"
+tags: ["colombia packing list", "travel tips", "what to pack"]
+---
+
+Antioquia's climate is one of the more forgiving in South America to pack for — Medellín's "eternal spring" means you won't need heavy winter layers or extreme heat protection. But the region's mix of city days, mountain hikes, and sudden afternoon rain does call for some specific choices.
+
+## Clothing
+
+- **Light layers over heavy jackets.** Medellín itself rarely gets cold, but mountain towns like Jardín or higher-altitude stops can be noticeably cooler, especially in the early morning or evening.
+- **A packable rain jacket or poncho.** Afternoon downpours are common in the wetter months (roughly April–May and October–November) and can happen even in the drier ones. This is the single most useful item for day trips.
+- **Comfortable walking shoes**, plus a pair of real hiking shoes or boots if you're planning hikes like Cueva del Esplendor in Jardín or the Salto del Buey trails — sandals won't hold up on muddy mountain trails.
+- **A swimsuit**, for Guatapé's reservoir activities or Hacienda Nápoles' water park.
+- **Modest, casual clothing for city days** — Medellín's dress code is generally relaxed, and light, breathable fabrics work well given the consistent warm-to-mild temperatures.
+
+## Gear worth bringing
+
+- **A daypack** for day trips — something that can hold a rain layer, water, and a camera comfortably.
+- **A portable charger.** Long day-trip days with lots of photos can drain a phone fast, especially if you're using it for navigation too.
+- **Sunscreen and insect repellent.** Even with mild temperatures, Antioquia's elevation means stronger sun exposure than you might expect, and lower-altitude stops like Hacienda Nápoles or Rio Claro are more humid and buggier.
+- **A reusable water bottle.** Tap water in Medellín is generally considered safe to drink, and refilling instead of buying bottled water adds up over a longer trip.
+
+## Documents and money
+
+- **Passport with at least six months of validity**, standard for most international travel to Colombia.
+- **A copy of your passport**, stored separately from the original.
+- **A mix of cash and cards.** Colombia is increasingly card-friendly in cities, but smaller towns and pueblos often run more on cash — small denominations of Colombian pesos are worth carrying for day trips.
+- **A physical or digital copy of travel insurance details.**
+
+## What you probably don't need
+
+- **Heavy winter clothing.** Even Antioquia's cooler mountain towns rarely require more than a light jacket.
+- **Extensive formal wear.** Medellín's dress code, even for nicer restaurants, tends to be casual-to-smart-casual rather than formal.
+- **A universal adapter**, if you're coming from North America — Colombia uses the same plug types (A/B) and voltage as the US and Canada. Travelers from elsewhere should check compatibility.
+
+## A packing tip specific to day trips
+
+If you're doing multiple day trips during your stay, pack a small dedicated day-trip bag with the essentials — rain layer, sunscreen, water, snacks — so you're not repacking each morning. It's a small thing, but it saves real time across a week of early departures.
+
+Ready to put that packing list to use? Take a look at our [tours across Antioquia](/tours) to start building your itinerary.

--- a/src/content/blog/colombia-travel-tips-money-language-safety.md
+++ b/src/content/blog/colombia-travel-tips-money-language-safety.md
@@ -1,0 +1,57 @@
+---
+title: "A Beginner's Guide to Traveling in Colombia: Money, Language and Safety"
+description: "Practical first-time Colombia travel tips — currency and cash, basic Spanish phrases, SIM cards, and general safety habits for a smooth trip."
+date: "2026-07-08"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1749350820/roadmapcol/saltodelbuey/DJI_20241127_125105_379_i0fqid.jpg"
+tags:
+  [
+    "colombia travel tips",
+    "first time colombia",
+    "colombian pesos",
+    "spanish phrases",
+  ]
+---
+
+Colombia has become one of South America's most visited countries, and for first-timers, a handful of practical basics — money, language, connectivity — make the difference between a smooth trip and a stressful one. Here's what's actually useful to know before you land.
+
+## Money: pesos, cash, and cards
+
+Colombia's currency is the Colombian peso (COP), and prices can look intimidating at first simply because of the number of zeros involved — it's common to see everyday prices in the tens or hundreds of thousands. Take a moment on arrival to get comfortable with the exchange rate so prices feel intuitive rather than alarming.
+
+- **Cards are widely accepted in cities**, especially Medellín, at restaurants, hotels, and larger shops.
+- **Smaller towns and pueblos run more on cash.** If you're doing day trips to places like Jardín or the Oriente, carry enough cash for meals, small purchases, and tips.
+- **ATMs are common in cities** but less reliable in smaller towns — withdraw what you need before heading out on a day trip.
+- **Tipping** isn't as deeply ingrained as in the US, but is appreciated for guides and in restaurants; many restaurant bills already include a voluntary service charge you can decline if you prefer to tip directly.
+
+## Language: how much Spanish do you actually need
+
+English is spoken in tourist-oriented businesses in Medellín — hotels, many restaurants, tour operators — but far less so once you're outside the city or dealing with everyday situations like taxis, small shops, or pueblos. You don't need fluency, but a handful of phrases go a long way:
+
+- _Hola, ¿cómo está?_ — Hello, how are you?
+- _¿Cuánto cuesta?_ — How much does it cost?
+- _¿Dónde está...?_ — Where is...?
+- _La cuenta, por favor_ — The check, please.
+- _No hablo mucho español_ — I don't speak much Spanish (said with a smile, this usually gets a warmer response than you'd expect).
+- _Gracias, muy amable_ — Thank you, very kind. A common, friendly closer in everyday interactions.
+
+Paisas (people from Antioquia) are known nationally for being especially warm and welcoming to visitors — a little effort with basic Spanish is usually met with patience and genuine friendliness.
+
+## Staying connected
+
+Colombian SIM cards are inexpensive and widely available at the airport or in the city, and most major carriers offer prepaid data plans well suited to a short trip. Having local data makes ride-hailing apps, maps, and translation tools far more useful throughout your stay.
+
+## General safety habits
+
+Beyond the specifics covered in our [Medellín safety guide](/blog/is-medellin-safe-for-tourists), a few habits apply across Colombia generally:
+
+- Use ride-hailing apps over hailing taxis on the street.
+- Keep copies of important documents separate from the originals.
+- Avoid displaying expensive jewelry, watches, or electronics unnecessarily.
+- Stick to well-traveled areas after dark, especially as a first-time visitor.
+- Get comfortable with basic pricing so you can quickly sense-check quoted prices in markets or with informal vendors.
+
+## The bigger picture
+
+None of this is meant to make Colombia sound complicated — most of it becomes second nature within the first day or two of a trip. Colombia's combination of dramatic landscapes, warm culture, and genuine affordability (especially compared to other popular South American destinations) is exactly why it's become such a popular place to visit. A little preparation on money, language, and safety just lets you spend more of your trip enjoying that, and less time figuring out logistics.
+
+Ready to start planning? Take a look at our [guided tours across Antioquia](/tours) — a solid way to ease into the country with local support before venturing out on your own.

--- a/src/content/blog/colombian-food-guide-medellin-antioquia.md
+++ b/src/content/blog/colombian-food-guide-medellin-antioquia.md
@@ -1,0 +1,42 @@
+---
+title: "Colombian Food Guide: Must-Try Dishes in Medellín and Antioquia"
+description: "A guide to Paisa cuisine — bandeja paisa, arepas, trout in Guatapé, and the coffee culture of Jardín — plus tips on where and how to try it."
+date: "2026-06-30"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1749945185/roadmapcol/jardin/ardin-5_jf7e6u.jpg"
+tags: ["colombian food", "medellin restaurants", "paisa cuisine"]
+relatedTourHref: "/tours/jardin"
+---
+
+Antioquia's food culture — known locally as _Paisa_ cuisine — is hearty, built around beans, rice, corn, and meat, and shaped by the region's agricultural roots. Here's what to look for on a trip through Medellín and the surrounding pueblos.
+
+## Bandeja Paisa
+
+The signature dish of the region, and something every first-time visitor should try at least once. A bandeja paisa is a large platter combining red beans, rice, ground beef, chicharrón (fried pork belly), a fried egg, plantain, avocado, and an arepa — built to feed someone doing a full day of physical farm work, and portioned accordingly. Come hungry.
+
+## Arepas
+
+Arepas — grilled or griddled corn cakes — show up at nearly every meal in Antioquia, often plain and used as a side rather than stuffed the way they're served in some other Colombian regions. Simple, but a genuine staple you'll see constantly.
+
+## Trout (Trucha) around Guatapé
+
+The reservoir towns around Guatapé are known for freshwater trout, usually grilled or fried whole and served with patacones (fried plantain) and rice. It's the regional specialty to order if you're doing a Guatapé day trip.
+
+## Coffee, especially in Jardín
+
+Antioquia sits in Colombia's coffee-growing heartland, and towns like Jardín produce some of the region's better beans. A working farm visit typically walks you through the process from plant to cup, and the coffee itself — often served black, strong, and in small portions called _tinto_ — is worth trying throughout your trip, not just at farms.
+
+## Chorizo and other street food
+
+Grilled chorizo, often served with arepa and lime, is a common street food option, along with empanadas and buñuelos (fried cheese bread, especially popular around the holidays). Comuna 13 and other tour stops in Medellín typically have vendors selling these along the route.
+
+## Aguardiente and fruit juices
+
+Aguardiente, an anise-flavored spirit, is Antioquia's traditional drink of choice for celebrations. On the non-alcoholic side, Colombia's fruit variety is genuinely impressive — juices made from lulo, maracuyá (passion fruit), guanábana, and other fruits rarely seen outside South America are worth trying at any restaurant.
+
+## A few tips for eating well in the region
+
+- **Ask for the "menu del día"** at lunch in smaller restaurants — a set daily menu, usually soup, a main, and a juice, often the best value and most authentic option.
+- **Pueblos tend to have better home-style cooking than tourist-facing restaurants in the city** — a home-cooked lunch in Jardín or during an Oriente day trip is often more memorable than a city restaurant meal.
+- **Portions are large.** Bandeja paisa in particular is often meant to be shared or eaten across a longer, slower meal.
+
+Food is one of the best reasons to build day trips into your Medellín itinerary — our [Jardín tour](/tours/jardin) includes a coffee farm visit as one of its optional activities, a good way to combine the region's food culture with its landscape.

--- a/src/content/blog/comuna-13-graffitour-medellin-guide.md
+++ b/src/content/blog/comuna-13-graffitour-medellin-guide.md
@@ -1,0 +1,37 @@
+---
+title: "Comuna 13 Graffitour: What to Expect and Why It's a Must-Do in Medellín"
+description: "A first-timer's guide to visiting Comuna 13 in Medellín — its history, the outdoor escalators, the street art, and how to visit respectfully."
+date: "2026-05-08"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1771548806/roadmapcol/comuna13/comuna13_vbwhk6.jpg"
+tags: ["comuna 13", "medellin things to do", "street art", "city tours"]
+relatedTourHref: "/tours/comuna13"
+---
+
+Comuna 13 shows up on almost every Medellín itinerary, and for good reason. It's one of the few places in the city where you can see, in a single afternoon, how far a neighborhood can travel — from being one of the most dangerous parts of Medellín in the 1990s to becoming a symbol of the city's transformation through art, music, and public investment.
+
+## A brief bit of context
+
+Comuna 13 sits on a steep hillside on the western edge of the city. During the worst years of the conflict, the neighborhood's geography — narrow streets, no through-roads, and stairways instead of avenues — made it strategically important and, as a result, dangerous. In 2011, the city installed a series of outdoor escalators to connect the hillside community to the rest of Medellín, cutting what used to be a grueling walk into a few minutes. That same year, local youth collectives began turning the neighborhood's walls into murals telling their own story.
+
+## What you'll actually see
+
+- **The outdoor escalators**, still in daily use by residents, now framed by murals on both sides.
+- **Large-scale graffiti and murals**, many of them painted by local artists who lived through the period they're depicting.
+- **Live hip-hop and breakdance performances**, often put on informally by young performers from the neighborhood.
+- **Viewpoints over the city**, since Comuna 13 sits high enough to see a wide stretch of the Aburrá Valley.
+
+Every mural has a story, and most of them are more legible with context — a guide who grew up in or near the area, or who works closely with the local collectives, will point out details and meanings that are easy to miss walking through on your own.
+
+## Visiting respectfully
+
+Comuna 13 is a residential neighborhood, not a theme park. Tips that go a long way:
+
+1. Buy from the vendors and artists working along the route — much of the tourism revenue goes directly back into the community.
+2. Ask before taking close-up photos of people, especially performers between sets.
+3. Tip local guides and performers if you can; many of the youth programs that maintain the art are self-funded.
+
+## Combining it with the rest of the city
+
+Comuna 13 pairs naturally with a broader city tour, since it's usually done alongside stops in other well-known parts of Medellín and doesn't require a full day on its own. It's also one of the more accessible experiences for travelers with limited mobility, since the escalators do most of the climbing for you — though there are still some stairs and uneven surfaces along the mural route.
+
+Our [Comuna 13 city tour](/tours/comuna13) covers the neighborhood along with other representative spots in Medellín, with a private guide who can walk you through the history behind what you're seeing, not just the photo stops.

--- a/src/content/blog/guatape-el-penol-day-trip-medellin.md
+++ b/src/content/blog/guatape-el-penol-day-trip-medellin.md
@@ -1,0 +1,39 @@
+---
+title: "Guatapé and El Peñol: The Ultimate Day Trip from Medellín"
+description: "How to plan a day trip to Guatapé and El Peñol from Medellín: what to see, how to get there, and why this is Antioquia's most popular excursion."
+date: "2026-05-05"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1749941780/roadmapcol/guatape/guatape_yv0q5f.jpg"
+tags: ["guatape", "el peñol", "day trips from medellin", "antioquia travel"]
+relatedTourHref: "/tours/guatape"
+---
+
+If you only have time for one day trip outside Medellín, most locals will point you to the same place: Guatapé. Around two hours east of the city, this small town and its neighboring rock formation, El Peñol, make up the most photographed excursion in Antioquia — and it earns the reputation.
+
+## Why Guatapé is worth the trip
+
+Guatapé is known for two things: a reservoir dotted with islands and coves, and streets lined with colorful _zócalos_ — hand-painted relief panels that decorate the base of almost every building. Wander a few blocks from the main square and you'll see decades of local family history painted directly onto the walls.
+
+Right next to town is El Peñol, a 200-meter granite monolith with a staircase of roughly 700 steps built into a crack in the rock. At the top, the reservoir spreads out below in every direction — it's one of the defining views of Antioquia.
+
+## What to do once you're there
+
+- **Climb El Peñol.** The stairs are steep but manageable at a relaxed pace, with rest platforms along the way.
+- **Walk the town center.** Guatapé's zócalos are worth exploring on foot, ideally with someone who can point out the details you'd otherwise miss.
+- **Get out on the water.** A boat ride across the reservoir is the best way to see the flooded valley, the old town ruins, and a handful of famous former lakeside properties — including one that belonged to Pablo Escobar.
+- **Try the local trout.** Freshwater trout, grilled or fried, is the signature dish around the reservoir.
+
+For travelers who want a bit more adrenaline, jet skiing and wakesurfing on the reservoir have become popular add-ons, and a short helicopter flight over El Peñol is now available for those who want the postcard view without the stairs.
+
+## Getting there
+
+Guatapé is doable as a self-guided trip, but the town and the rock are a few kilometers apart, and public transport between them can eat into your day. Most visitors find it easier to go with private round-trip transportation from Medellín, which also means you don't have to plan bus schedules around getting back.
+
+## How much time to set aside
+
+A full day is the right amount of time. Between the drive, the climb, lunch, and a boat ride, you'll want at least 8 hours if you're coming from Medellín. Trying to combine Guatapé with another destination on the same day usually means rushing through both.
+
+If you'd rather not coordinate transportation, entrance tickets, and a boat separately, our [Guatapé day tour](/tours/guatape) bundles round-trip transport, a guide, and snacks, with optional add-ons like the boat cruise, jet ski, or helicopter flight.
+
+## A quick tip
+
+Go early. Guatapé is a popular weekend destination for Medellín locals, and the climb up El Peñol gets crowded by midday, especially on Saturdays and Sundays. An early departure also gives you softer light for photos at the top.

--- a/src/content/blog/hacienda-napoles-pablo-escobar-theme-park.md
+++ b/src/content/blog/hacienda-napoles-pablo-escobar-theme-park.md
@@ -1,0 +1,44 @@
+---
+title: "Hacienda Nápoles: Inside Pablo Escobar's Former Estate, Now a Theme Park"
+description: "What to expect at Hacienda Nápoles, the theme park built on Pablo Escobar's former estate — the zoo, water park, and Rio Claro canyon nearby."
+date: "2026-05-20"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1771549653/roadmapcol/haciendaNapoles/haciendaNapoles_j3t4qi.jpg"
+tags:
+  [
+    "hacienda napoles",
+    "pablo escobar tourism",
+    "doradal",
+    "day trips from medellin",
+  ]
+relatedTourHref: "/tours/hacienda-napoles"
+---
+
+Hacienda Nápoles is one of the stranger stops on an Antioquia itinerary, and also one of the most talked about. Once the private estate of Pablo Escobar — complete with an airstrip and an imported private zoo — it's now a family theme park that keeps a small part of that history visible while building something new on top of it.
+
+## From private estate to public park
+
+At the height of his power, Escobar built Hacienda Nápoles as a personal retreat, stocking it with exotic animals brought in from abroad, including a herd of hippos that famously outlived the estate's original owner and went on to become an ecological issue of their own in the region's rivers. After Escobar's death and the eventual seizure of the property, the Colombian government converted the site into a public theme park, with proceeds going toward victims of the conflict.
+
+Today, a handful of relics from that era remain on the grounds — most notably a small collection of vehicles — alongside a much larger footprint of family attractions built since.
+
+## What's there now
+
+- **A large water park**, one of the bigger draws for families, with pools and slides spread across the grounds.
+- **A zoo**, home to various species descended from and alongside Escobar's original collection, including the hippos.
+- **Museums and exhibits** covering both the natural history angle (dinosaur replicas are a longtime park fixture) and the more complicated history of the estate itself.
+
+It's a full day out, and the site is large enough that most visitors don't see everything in one visit — worth deciding in advance whether the water park, the zoo, or the museums are the priority for your group.
+
+## Rio Claro Canyon, right next door
+
+A short distance from Hacienda Nápoles is Rio Claro, a canyon known for its marble-walled river, caves, and rafting. It's a strong complement to a Hacienda Nápoles visit if you have more than a day in the area — hiking, cave exploring, and rafting are all on offer, and the scenery is a real change of pace from the theme park.
+
+## Planning your visit
+
+Hacienda Nápoles is roughly 3 hours from Medellín in the direction of Doradal, in the lower, hotter part of Antioquia known locally as _tierra caliente_. It's a long day if done as a round trip, so most visitors plan for a full day, starting early.
+
+- Bring sunscreen and light clothing — the climate near Doradal is noticeably hotter and more humid than Medellín.
+- If both the theme park and Rio Claro interest you, consider whether to split them across two days or pick one to focus on.
+- Groups are recommended given the distance and the amount of coordination involved.
+
+Our [Hacienda Nápoles tour](/tours/hacienda-napoles) includes private round-trip transportation from Medellín, with add-ons for the theme park, Rio Claro hiking and rafting, and quad bike or buggy tours around the area — minimum group size of 3 people.

--- a/src/content/blog/how-to-get-around-medellin.md
+++ b/src/content/blog/how-to-get-around-medellin.md
@@ -1,0 +1,45 @@
+---
+title: "How to Get Around Medellín: Metro, Cable Car, Taxis and More"
+description: "A practical guide to Medellín's transportation system — the metro, the Metrocable, ride-hailing apps, taxis, and when it makes sense to book private transport."
+date: "2026-06-14"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1749422811/roadmapcol/comuna13/IMG_2476_xoptdu.webp"
+tags: ["medellin metro", "medellin transportation", "getting around medellin"]
+relatedTourHref: "/tours/comuna13"
+---
+
+Medellín's transportation system is one of the city's genuine strengths, and understanding it early in your trip will save you both time and money. Here's how the main pieces fit together.
+
+## The Metro
+
+Medellín's metro is the backbone of the city's public transit, running mostly above ground on elevated tracks through the Aburrá Valley. It's clean, reliable, affordable, and connects most of the areas travelers care about, including transfers to the city's cable car lines. Locals take real pride in the system — it was the first metro in Colombia and remains a symbol of the city's modernization, which is part of why it stays so well maintained.
+
+Buy a rechargeable Cívica card at any station to use the metro, buses, and cable cars under one system.
+
+## The Metrocable
+
+Where the metro's tracks end, Medellín's Metrocable — a network of cable car lines — picks up, climbing into the hillside neighborhoods that surround the valley. Originally built to connect underserved communities to the rest of the city, the Metrocable doubles as one of the best low-cost viewpoints in Medellín: the ride up offers wide views over the city that would otherwise cost a tour or a hike to get.
+
+## Ride-hailing apps
+
+Apps like Uber and Didi operate in Medellín and are widely used by both locals and tourists. They're generally the easiest and safest way to get around at night or to destinations the metro doesn't reach directly, since the fare and route are set in advance.
+
+## Street taxis
+
+Traditional taxis are common and metered, but picking one up on the street — rather than through an app or having your hotel call one — carries a higher (though still relatively low) risk of overcharging or, less commonly, safety issues. If you do flag a street taxi, having your hotel or restaurant call one for you is safer than hailing one at random, especially at night.
+
+## Buses
+
+Medellín's bus network is extensive but takes more local knowledge to navigate confidently — routes aren't always clearly signed in ways that are intuitive for first-time visitors. Most tourists rely on the metro, cable car, and ride-hailing apps instead, saving buses for once they're more familiar with the city.
+
+## When private transportation makes more sense
+
+For day trips outside the city — Guatapé, Jardín, Hacienda Nápoles, and similar destinations — public transport gets a lot less convenient. Regional buses exist but run on fixed schedules that can eat into your day, and connections between the town center and outlying attractions (like El Peñol from Guatapé's bus terminal) often require additional coordination.
+
+For day trips, private round-trip transportation removes that friction entirely — no schedules to work around, no juggling luggage between terminals, and a guide who can add context along the way. All of our [day trip tours](/tours) include private transportation as standard.
+
+## Quick reference
+
+- **Around the city, short distances:** walk, or ride-hailing app.
+- **Around the city, longer distances:** metro plus Metrocable where relevant.
+- **At night:** ride-hailing app over street taxis.
+- **Day trips outside the city:** private transportation, ideally booked in advance.

--- a/src/content/blog/is-medellin-safe-for-tourists.md
+++ b/src/content/blog/is-medellin-safe-for-tourists.md
@@ -1,0 +1,36 @@
+---
+title: "Is Medellín Safe for Tourists? A Practical, No-Drama Guide"
+description: "A practical look at safety in Medellín for tourists — which areas are well-traveled, common-sense precautions, and how the city has changed."
+date: "2026-06-06"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/w_1920,q_auto,f_auto/v1748229430/roadmap/tourism_nsahmt.avif"
+tags: ["medellin safety", "colombia travel tips", "first time in medellin"]
+---
+
+This is the single most common question we get from first-time visitors, and it deserves a straight answer: Medellín today is a very different city from the one people remember from the 1990s and early 2000s. Millions of tourists visit every year without incident, and the areas travelers actually spend time in — El Poblado, Laureles, the city center on organized tours — are well-traveled and generally safe with normal precautions.
+
+That said, "safe" isn't the same as "identical to home," and a bit of context goes a long way.
+
+## Why Medellín's reputation lags behind reality
+
+Medellín's association with cartel violence is decades old at this point, but pop culture (documentaries, TV shows) keeps that period in the public imagination long after the city itself moved on. Investment in public transit, education, and public space transformed neighborhoods that were once no-go zones — Comuna 13 being the most visible example — into some of the city's most visited areas. The city's homicide rate has fallen dramatically since its peak, and the day-to-day experience for a tourist reflects that shift far more than the old headlines do.
+
+## Practical precautions that actually matter
+
+- **Use ride-hailing apps or trusted transportation instead of hailing taxis on the street**, especially at night.
+- **Keep valuables low-key.** Flashy jewelry and openly displayed phones draw the same kind of opportunistic theft they would in any major city.
+- **Stick to well-traveled areas after dark**, particularly if you're not familiar with a neighborhood yet.
+- **Avoid political demonstrations and large crowds** you don't have context for, as a general rule in any country.
+- **Be cautious with drinks in nightlife settings** — spiking incidents, while not common, do happen in party-heavy areas like El Poblado's Parque Lleras.
+- **Don't buy drugs.** Beyond the legal risk, this is the single biggest factor connecting tourists to genuinely dangerous situations in Medellín.
+
+None of this is Medellín-specific advice, really — it's the same baseline caution worth applying in any large city, adjusted slightly for local context.
+
+## Which areas are considered safest for visitors
+
+El Poblado and Laureles are the two neighborhoods most travelers base themselves in, both well-served by hotels, restaurants, and the metro system. Guided tours to areas like Comuna 13 are widely run and considered safe specifically because of the transformation that neighborhood has undergone — going with a local guide who knows the area adds an extra layer of comfort if you're unsure.
+
+## The honest bottom line
+
+Millions of tourists, digital nomads, and expats live in and visit Medellín every year with no issues. The city isn't risk-free — no major city is — but it's not the place its old reputation suggests either. Ordinary street-smarts, sticking to well-traveled areas, and going with a guide for excursions outside the city center covers the vast majority of what you need to know.
+
+If you're new to the city, booking your first few days as guided experiences — rather than figuring out logistics solo from day one — is a low-effort way to get comfortable with how the city works before venturing out on your own. Take a look at our [full list of tours](/tours) for guided ways to see Medellín and Antioquia.

--- a/src/content/blog/jardin-antioquia-travel-guide.md
+++ b/src/content/blog/jardin-antioquia-travel-guide.md
@@ -1,0 +1,40 @@
+---
+title: "Jardín, Antioquia: A Complete Guide to Colombia's Prettiest Pueblo"
+description: "Everything to know before visiting Jardín, Antioquia — the coffee farms, Cueva del Esplendor waterfall, waterfalls hike, and how to get there from Medellín."
+date: "2026-05-12"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1771549017/roadmapcol/jardin/jardin_a8u1ox.jpg"
+tags: ["jardin antioquia", "pueblos colombia", "coffee region", "day trips"]
+relatedTourHref: "/tours/jardin"
+---
+
+Ask several Medellín locals for their favorite pueblo, and Jardín comes up more often than any other. Around 2.5 hours south of the city, it has the colorful architecture travelers expect from an Antioquian town, plus something a lot of the more famous pueblos don't: real coffee country right at its edges, and mountains that are genuinely worth hiking into.
+
+## What makes Jardín different
+
+Jardín's main square is postcard material — cane chairs spilling out of cafés, a neo-gothic church, and buildings painted in the bright greens and blues typical of the region. But unlike some more touristy pueblos, Jardín still functions as a working agricultural town. Coffee is the backbone of the local economy, and that shapes everything from the food to the daily rhythm of the place.
+
+## Things to do
+
+**Visit a working coffee farm.** Jardín's climate and altitude make it one of the better coffee-growing zones in Antioquia. A farm visit typically walks you through the full process, from the plant to the cup, with a tasting at the end.
+
+**Hike to Cueva del Esplendor.** This is Jardín's signature natural attraction: a cave with a waterfall pouring through a hole in its roof. Getting there is a moderate, roughly 40-minute hike, usually combined with a short jeep ride (locals use old Willys jeeps as shared transport in and around town — riding one is part of the experience).
+
+**Take on the Seven Waterfalls hike** if you want something more demanding. It's a full-day trek through one of the wettest parts of the region, passing several waterfalls along the way. Good footwear and a reasonable fitness level are a must.
+
+**Ride the cable car.** A small cable car climbs out of town to a nearby viewpoint — a low-effort way to see Jardín from above.
+
+**Just sit in the square.** Genuinely one of the better people-watching spots in Antioquia, especially in the late afternoon when farmers and townspeople gather for coffee.
+
+## Planning your visit
+
+Jardín works well as a long day trip from Medellín, though travelers who want to slow down sometimes stay a night to catch the town in the early morning before day-trippers arrive. If you're short on time, a single day is enough to see the square, do the Cueva del Esplendor hike, and fit in a coffee farm visit.
+
+The drive down is scenic in its own right, winding through mountain roads and smaller towns — one more reason private transportation is worth it over public buses if your schedule is tight.
+
+## Planning tips
+
+- Bring a light rain layer — Jardín's microclimate can shift quickly, even on a mostly sunny day.
+- Wear real hiking shoes if you're doing Cueva del Esplendor or the Seven Waterfalls hike; the trails get muddy.
+- If coffee is the main draw for you, ask specifically for a working farm rather than a purely touristic tasting room — the two experiences are quite different.
+
+Our [Jardín day trip](/tours/jardin) covers round-trip transport from Medellín along with a local guide, with the coffee tour, Cueva del Esplendor, and the Seven Waterfalls hike all available as add-on activities depending on how active you want the day to be.

--- a/src/content/blog/mavi-cartagena-sunset-cruise-guide.md
+++ b/src/content/blog/mavi-cartagena-sunset-cruise-guide.md
@@ -1,0 +1,33 @@
+---
+title: "MAVI Cartagena: How to Spend a Sunset on Cartagena Bay"
+description: "What to expect from a MAVI boat experience in Cartagena — sunset cruises, celebrations on the water, and tips for booking a bay tour."
+date: "2026-05-16"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1771549980/roadmapcol/maviCartagena/2c67bd94-35e4-4c70-98f0-585d0388fb67_nrkmz9.jpg"
+tags: ["cartagena", "boat tours", "things to do in cartagena"]
+relatedTourHref: "/tours/mavi-cartagena"
+---
+
+Cartagena's Old City gets most of the attention — the walls, the balconies, the plazas — but some of the best views of the city are from the water, looking back at it. That's the appeal of a bay cruise aboard a vessel like the MAVI: you get Cartagena's skyline, the sunset over the Caribbean, and a very different pace than walking the cobblestone streets in the heat.
+
+## Why do a boat tour in Cartagena
+
+Cartagena Bay opens up views that are hard to get any other way — the walled city from offshore, the modern skyline of Bocagrande in the distance, and, depending on the route, some of the smaller islands nearby. It's also simply more comfortable: a breeze off the water is a welcome break from the humidity of the streets, especially in the late afternoon.
+
+## What a typical experience looks like
+
+A vessel like the MAVI is built for groups and events — birthdays, weddings, corporate outings, or just a group of friends wanting to watch the sunset with music and drinks on board. Bookings are flexible by the hour, which makes it easy to build around whatever else is on your Cartagena itinerary that day.
+
+Sunset departures are the most popular option, and for good reason: the light over the bay in the final hour before dark is some of the best in the city, and temperatures are noticeably more comfortable than midday.
+
+## Tips for booking
+
+- **Book ahead for sunset slots.** The window for the best light is fixed by the time of year, so popular departure times fill up, especially on weekends.
+- **Confirm capacity if you're booking for a group.** Vessels like the MAVI can hold up to around 40 people, which makes it a solid option for larger celebrations, but you'll want the numbers confirmed in advance.
+- **Ask what's included.** Bay cruises can range from a simple charter to a fully catered event — worth clarifying before you book if you're planning something specific like a birthday or anniversary.
+- **Bring a light layer.** It can get breezy on open water even on a hot day.
+
+## Pairing it with the rest of your Cartagena trip
+
+A bay cruise works well as an evening activity after a day spent walking the Old City and the walls, since it doesn't require much walking and gives your legs a break while still keeping you outdoors. It's also a natural way to close out a day if you're celebrating something during your trip.
+
+If you're planning a private event, sunset outing, or just want to see Cartagena from the water, our [MAVI Cartagena experience](/tours/mavi-cartagena) can be booked by the hour and set up around what you have in mind, from a relaxed sunset ride to a full celebration on board.

--- a/src/content/blog/medellin-itinerary-3-5-7-days.md
+++ b/src/content/blog/medellin-itinerary-3-5-7-days.md
@@ -1,0 +1,49 @@
+---
+title: "3, 5 or 7 Days in Medellín: How to Plan the Perfect Itinerary"
+description: "Sample Medellín itineraries for 3, 5 and 7 days, balancing city highlights like Comuna 13 with day trips to Guatapé, Jardín and beyond."
+date: "2026-06-18"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1749420263/roadmapcol/guatape/IMG_0028_fmsxte.webp"
+tags:
+  ["medellin itinerary", "colombia trip planning", "things to do in medellin"]
+relatedTourHref: "/tours"
+---
+
+The right Medellín itinerary depends almost entirely on how many days you have, since the city itself can be seen in a couple of days, but the surrounding region — Guatapé, Jardín, the Oriente, Hacienda Nápoles — genuinely rewards more time. Here's how we'd split it at three different trip lengths.
+
+## If you have 3 days
+
+With only three days, prioritize one city day and one day trip, and keep the third day flexible.
+
+- **Day 1 — Medellín city highlights:** Comuna 13, a walk through El Poblado or Laureles, and a proper Antioquian meal.
+- **Day 2 — One day trip:** Guatapé is the classic choice for a first visit — iconic, efficient, and satisfying in a single day.
+- **Day 3 — Your choice:** Paragliding for an adrenaline morning, or a slower day exploring local markets and neighborhoods you didn't get to on day one.
+
+## If you have 5 days
+
+Five days is enough to add a second day trip and slow the pace down slightly.
+
+- **Day 1 — Arrival and orientation:** Settle in, walk El Poblado or Laureles, adjust to the altitude.
+- **Day 2 — Comuna 13 and the city center:** Murals, history, and the metro/Metrocable system.
+- **Day 3 — Guatapé:** The full day trip, including the climb up El Peñol.
+- **Day 4 — Jardín or the Oriente:** Jardín if you want a coffee-and-waterfall day; the Oriente if you'd rather puebliar at a slower pace.
+- **Day 5 — Adventure or rest:** Paragliding or the Salto del Buey canopy tour if you have energy left, or a relaxed day if the pace has caught up with you.
+
+## If you have 7 days
+
+A full week lets you add Hacienda Nápoles, which is a longer day trip, plus real downtime.
+
+- **Days 1–2:** City orientation, Comuna 13, neighborhood exploring.
+- **Day 3:** Guatapé.
+- **Day 4:** Jardín.
+- **Day 5:** Hacienda Nápoles and Rio Claro (this is a long day — build in a lighter day 6 afterward).
+- **Day 6:** Rest, or paragliding/canopy tour if you're up for one more adventure day.
+- **Day 7:** A slower final day — markets, cafés, and anything you missed.
+
+## General planning tips
+
+- **Don't stack two full day trips back to back** unless you have to — Guatapé, Jardín, and Hacienda Nápoles are each satisfying full days, and doing them consecutively tends to feel rushed.
+- **Book day trips with private transportation** rather than public buses if your schedule is tight — it removes the biggest source of wasted time.
+- **Leave at least one unstructured day**, especially on longer trips. Some of the best parts of Medellín aren't on any itinerary.
+- **Consider your altitude adjustment.** Medellín sits around 1,500 meters — most travelers don't notice it, but it's worth a lighter first day if you're arriving from sea level and planning an active trip.
+
+Whatever length trip you're planning, our [full list of tours](/tours) covers all of the day trips mentioned above, and can be mixed and matched around your schedule.

--- a/src/content/blog/medellin-vs-cartagena.md
+++ b/src/content/blog/medellin-vs-cartagena.md
@@ -1,0 +1,42 @@
+---
+title: "Medellín vs Cartagena: Which Colombian City Should You Visit First?"
+description: "Medellín and Cartagena offer very different trips — mountains vs coast, day trips vs beach lounging. Here's how to decide which to visit first, or how to do both."
+date: "2026-06-22"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/f_auto/v1771549983/roadmapcol/maviCartagena/a533a6c1-d9e1-44cb-917e-6c60f9a7ee5a_z3gftr.jpg"
+tags:
+  ["medellin vs cartagena", "colombia destinations", "where to go in colombia"]
+relatedTourHref: "/tours/mavi-cartagena"
+---
+
+Colombia's two most-visited cities couldn't be more different, and that's exactly why the "Medellín or Cartagena?" question comes up so often. One is a mountain city with a cool, spring-like climate and easy access to day trips; the other is a walled colonial port on the Caribbean coast, hot and humid, built for a slower, beach-adjacent pace. Neither is objectively "better" — they suit different kinds of trips.
+
+## Medellín, in short
+
+Medellín is a city of neighborhoods and day trips. El Poblado and Laureles offer a modern, walkable base with strong food and nightlife scenes, while the surrounding region — Guatapé, Jardín, Hacienda Nápoles, the Oriente — gives you a different landscape almost every day without needing to change hotels. The climate stays mild year-round, which makes it comfortable for hiking, paragliding, and other outdoor activities.
+
+**Medellín is the better fit if you want:** a home base with easy day trips into the mountains, cooler weather, and a mix of city and nature in the same trip.
+
+## Cartagena, in short
+
+Cartagena is built around its walled Old City — a UNESCO World Heritage Site with colonial architecture, plazas, and balconies dripping with bougainvillea — plus the Caribbean itself, with beaches and island day trips a short boat ride away. It's hotter and more humid than Medellín, and the pace is generally slower: more strolling and lounging, less hiking and adventure sports.
+
+**Cartagena is the better fit if you want:** beach time, colonial architecture, Caribbean nightlife, and a warmer, more languid trip overall.
+
+## What about doing both?
+
+If your schedule allows, Medellín and Cartagena pair well as a two-city trip — there are frequent direct flights between them, generally under an hour and a half in the air. A common structure is several days in Medellín for the city and day trips, followed by a shorter, more relaxed stretch in Cartagena to close out the trip with beach time and colonial streets.
+
+## Quick comparison
+
+|           | Medellín                              | Cartagena                    |
+| --------- | ------------------------------------- | ---------------------------- |
+| Climate   | Mild, spring-like year-round          | Hot, humid, coastal          |
+| Pace      | Active — day trips, hiking, adventure | Relaxed — beaches, strolling |
+| Landscape | Mountains and valleys                 | Caribbean coast              |
+| Best for  | Nature, adventure, city + day trips   | Beaches, history, nightlife  |
+
+## Our take
+
+If you only have time for one city and you enjoy being active outdoors, choose Medellín. If your priority is beach time and colonial charm, choose Cartagena. If you can manage both, even a shorter Cartagena add-on at the end of a Medellín-based trip is worth it — the contrast between the two is part of what makes Colombia such a varied destination.
+
+Planning a Cartagena stop? A sunset cruise on [MAVI Cartagena](/tours/mavi-cartagena) is one of the best ways to see the bay and the Old City skyline from the water.

--- a/src/content/blog/orient-tour-antioquia-pueblos-guide.md
+++ b/src/content/blog/orient-tour-antioquia-pueblos-guide.md
@@ -1,0 +1,36 @@
+---
+title: "Puebliar in Antioquia's Eastern Highlands: The Orient Tour Guide"
+description: "What 'puebliar' means and why the Oriente Antioqueño, the eastern highlands near Medellín, is one of the best regions in Colombia to slow down and explore small towns."
+date: "2026-06-02"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1749944605/roadmapcol/oriente/oriente-1_jbhthn.jpg"
+tags: ["antioquia pueblos", "oriente antioqueño", "medellin day trips"]
+relatedTourHref: "/tours/orient-tour"
+---
+
+Ask a Paisa what they do on a free Sunday, and a common answer is "voy a puebliar" — roughly, "I'm going pueblo-hopping." It's a favorite local pastime: driving out from Medellín to nearby small towns for lunch, coffee, and a walk around the square, then heading back before dark. The Oriente Antioqueño, the eastern highlands region just outside the city, is where most of that happens.
+
+## What the Oriente Antioqueño is
+
+Unlike the more famous single-destination day trips (Guatapé, Jardín), the Oriente is really a region — a cluster of small towns in the hills east of Medellín, each with its own character, connected by mountain roads through farmland, plant nurseries, and rural estates. It's less about seeing one landmark and more about experiencing how locals actually spend their weekends.
+
+## What "puebliar" looks like in practice
+
+A typical day involves stopping in one or two towns rather than covering ground quickly. Locals will walk the main square, sit for coffee or a full lunch at a family-run restaurant, browse whatever local produce or crafts are being sold that day, and just take in the pace of small-town Antioquia — genuinely slower than Medellín, even though you're less than an hour away.
+
+## Why it's worth doing
+
+The Oriente doesn't have a single blockbuster attraction the way Guatapé has El Peñol, and that's part of the appeal. It's the region to choose if you've already done the "must-see" stops around Medellín and want a more authentic, less touristic day — small-town plazas, home-style Antioquian cooking, and a slower rhythm that's hard to find at the more visited destinations.
+
+It's also a good fit for travelers who want to understand daily life in the region rather than just photograph landmarks. The towns of the Oriente are still primarily built around agriculture, flower and plant nurseries, and local commerce, not tourism.
+
+## What to expect on the trip
+
+- **Traditional Antioquian food**, often at family-run restaurants rather than tourist-facing ones.
+- **Small-town architecture and plazas**, similar in style to the more famous pueblos but with far fewer visitors.
+- **A slower pace overall** — this is a trip built around lingering, not checking off a list.
+
+## Planning tips
+
+Because the Oriente is a region rather than a single site, having a guide who knows which towns are worth stopping in on a given day makes a real difference — the right choice can depend on what's happening locally (markets, festivals) at the time of your visit.
+
+Our [Orient Tour](/tours/orient-tour) is built around this idea of puebliar — a guided day through the eastern highlands with round-trip transport and traditional snacks, designed for travelers who want a more local, unhurried side of Antioquia.

--- a/src/content/blog/paragliding-medellin-first-timers-guide.md
+++ b/src/content/blog/paragliding-medellin-first-timers-guide.md
@@ -1,0 +1,42 @@
+---
+title: "Paragliding in Medellín: Everything First-Timers Need to Know"
+description: "A first-timer's guide to tandem paragliding in Medellín — what it feels like, what to wear, and what determines whether you'll fly on a given day."
+date: "2026-05-25"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1771548688/roadmapcol/parapente/parapente_zo57qx.jpg"
+tags:
+  [
+    "paragliding medellin",
+    "adventure tourism",
+    "adrenaline activities colombia",
+  ]
+relatedTourHref: "/tours/paragliding"
+---
+
+Medellín sits in a valley ringed by mountains, which makes it one of the more reliable places in Colombia to paraglide. The thermals that rise off the surrounding hills give pilots consistent lift, and several launch points around the city offer views over the Aburrá Valley that are hard to get any other way.
+
+## What tandem paragliding actually involves
+
+If you've never flown before, tandem paragliding means you're harnessed in front of a certified pilot who controls the wing and handles takeoff and landing. You don't need any prior experience or particular fitness level — the hardest part, physically, is a short running start at launch, and even that's guided step by step by the pilot.
+
+Flights typically last somewhere around 15 to 25 minutes depending on conditions, gliding over the valley with views of Medellín's neighborhoods, the surrounding mountains, and, on clear days, a genuinely wide stretch of the city below.
+
+## What it actually feels like
+
+Most first-timers expect it to feel like a rollercoaster. It doesn't. Once you're airborne, paragliding is closer to floating than falling — there's a brief adrenaline spike at takeoff, and then the flight settles into something surprisingly calm. The biggest surprise for most people is how quiet it is once you're up.
+
+## What to wear and bring
+
+- **Closed-toe shoes with good grip** — sneakers or hiking shoes, not sandals.
+- **Layers.** It's noticeably cooler at launch altitude than in the city below.
+- **Nothing loose or easily dropped** — pockets that zip are safer than ones that don't, since you'll be harnessed and can't easily catch a falling phone.
+- **Sunglasses**, since you'll be facing into open air and sun for the duration of the flight.
+
+## What determines whether you fly
+
+Paragliding is weather-dependent. Wind speed and direction, visibility, and general conditions are all assessed by the pilots before every flight, and trips can be rescheduled on short notice if conditions aren't safe. This isn't a formality — it's the reason paragliding in Medellín has a strong safety record. If a flight gets postponed because of weather, treat it as the system working as intended, not a booking problem.
+
+## Is it worth doing if you're nervous about heights
+
+Most people who are nervous about heights on the ground report feeling fine once airborne — the sensation of being harnessed to an experienced pilot, combined with the slow, controlled nature of the flight, tends to be much less intimidating than the anticipation beforehand. That said, if heights are a genuine concern, it's worth being upfront with your pilot before takeoff so they can talk you through what to expect.
+
+Our [paragliding experience](/tours/paragliding) includes round-trip transport, a guided flight with a certified pilot, and traditional local snacks — no experience necessary.

--- a/src/content/blog/salto-del-buey-canopy-la-ceja.md
+++ b/src/content/blog/salto-del-buey-canopy-la-ceja.md
@@ -1,0 +1,40 @@
+---
+title: "El Salto del Buey Canopy Tour: Zip-Lining Through Antioquia's Mountains"
+description: "A guide to El Salto del Buey in La Ceja, Antioquia — the canopy zip-line, the waterfall hike, and extra activities like via ferrata and hanging hammocks."
+date: "2026-05-29"
+coverImage: "https://res.cloudinary.com/lesteban/image/upload/v1771547745/roadmapcol/saltodelbuey/canopy__owsi02.jpg"
+tags: ["salto del buey", "canopy tour", "la ceja antioquia", "adventure travel"]
+relatedTourHref: "/tours/salto-del-buey"
+---
+
+Not far from Medellín, the mountains around La Ceja hide one of Antioquia's better adventure combinations: a genuine waterfall hike paired with what's often described as the highest canopy zip-line circuit in the region.
+
+## What El Salto del Buey actually is
+
+El Salto del Buey is a waterfall tucked into the mountains of La Ceja, reached by a short hike through forest trail. The waterfall itself is worth the trip on its own, but the area has grown into a broader adventure hub, anchored by a canopy zip-line course that runs high above the same canyon.
+
+## The main activities
+
+**The canopy zip-line.** Multiple lines run across the Cañón del Buey at height, giving you a bird's-eye view of the canyon and waterfall below. It's suited to most fitness levels — you're clipped in and guided the whole way, so the main requirement is a willingness to step off a platform.
+
+**The waterfall hike.** A moderate walk through the forest leads to the base (or a viewpoint, depending on the route) of El Salto del Buey itself — a solid stop even for travelers who skip the more adrenaline-heavy activities.
+
+**Via ferrata for the more adventurous.** For those who want to go further, a guided via ferrata route lets you climb the rock face using fixed steel cables and anchors, no prior climbing experience required. You're harnessed throughout and guided by instructors.
+
+**Hanging hammocks over the canyon**, for the opposite kind of experience — a genuinely relaxing way to take in one of the better sunset views in the area, suspended above the Cañón del Buey with nothing to do but enjoy it.
+
+**A mountain picnic**, available either at the summit or in the hammocks, for travelers who want to build in a slower, more scenic stretch of the day — a cheese board and wine with a view, essentially.
+
+## Who this trip is for
+
+El Salto del Buey works for a wide range of travelers precisely because it isn't just one activity. Adventure-focused visitors can stack the zip-line, via ferrata, and a hike into one day; travelers who want something calmer can lean into the waterfall walk and the hammocks instead. It's also a solid option for groups with mixed interests, since everyone can choose their own level of intensity within the same trip.
+
+## Planning your visit
+
+La Ceja is close enough to Medellín that this works comfortably as a half-day or full-day trip, depending on how many activities you add on. Private transportation is the easiest way to get there, since the site itself is outside town and not well served by public transit.
+
+- Wear real shoes with grip — sandals won't work for the hike or the zip-line platforms.
+- Bring a light jacket; it's noticeably cooler and often more humid in the mountains than in Medellín.
+- If you're combining several activities (zip-line, via ferrata, hike), plan for closer to a full day rather than a half day.
+
+Our [Salto del Buey tour](/tours/salto-del-buey) includes private round-trip transportation, guided access to the waterfall and canopy zip-line, with via ferrata, hanging hammocks, and the mountain picnic available as add-ons.

--- a/src/lib/__tests__/blog.test.ts
+++ b/src/lib/__tests__/blog.test.ts
@@ -1,0 +1,52 @@
+import { getAllPostSlugs, getAllPosts, getPostBySlug } from '@/lib/blog'
+
+describe('blog', () => {
+  describe('getAllPostSlugs', () => {
+    it('returns at least 15 slugs', () => {
+      expect(getAllPostSlugs().length).toBeGreaterThanOrEqual(15)
+    })
+
+    it('returns unique slugs', () => {
+      const slugs = getAllPostSlugs()
+      expect(new Set(slugs).size).toBe(slugs.length)
+    })
+  })
+
+  describe('getPostBySlug', () => {
+    it('returns null for an unknown slug', () => {
+      expect(getPostBySlug('this-post-does-not-exist')).toBeNull()
+    })
+
+    it('returns full post data for a known slug', () => {
+      const [slug] = getAllPostSlugs()
+      const post = getPostBySlug(slug)
+      expect(post).not.toBeNull()
+      expect(post?.slug).toBe(slug)
+      expect(post?.title).toBeTruthy()
+      expect(post?.description).toBeTruthy()
+      expect(post?.coverImage).toMatch(/^https:\/\//)
+      expect(post?.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(Array.isArray(post?.tags)).toBe(true)
+      expect(post?.tags.length).toBeGreaterThan(0)
+      expect(post?.content.length).toBeGreaterThan(200)
+    })
+  })
+
+  describe('getAllPosts', () => {
+    it('returns posts sorted by date, most recent first', () => {
+      const dates = getAllPosts().map((post) => post.date)
+      const expectedDescending = [...dates].sort().reverse()
+      expect(dates).toEqual(expectedDescending)
+    })
+
+    it('every post has complete, well-formed frontmatter', () => {
+      getAllPosts().forEach((post) => {
+        expect(post.title.length).toBeGreaterThan(10)
+        expect(post.description.length).toBeGreaterThan(20)
+        expect(post.description.length).toBeLessThanOrEqual(170)
+        expect(post.coverImage).toMatch(/^https:\/\/res\.cloudinary\.com\//)
+        expect(post.tags.length).toBeGreaterThan(0)
+      })
+    })
+  })
+})

--- a/src/lib/__tests__/markdown.test.ts
+++ b/src/lib/__tests__/markdown.test.ts
@@ -1,0 +1,18 @@
+import { renderMarkdown } from '@/lib/markdown'
+
+describe('renderMarkdown', () => {
+  it('converts a heading to HTML', async () => {
+    const html = await renderMarkdown('## Hello')
+    expect(html).toContain('<h2>Hello</h2>')
+  })
+
+  it('converts a GFM table to an HTML table', async () => {
+    const html = await renderMarkdown('| A | B |\n|---|---|\n| 1 | 2 |')
+    expect(html).toContain('<table>')
+  })
+
+  it('converts a link to an anchor tag', async () => {
+    const html = await renderMarkdown('[Tours](/tours)')
+    expect(html).toContain('<a href="/tours">Tours</a>')
+  })
+})

--- a/src/lib/__tests__/structured-data.test.ts
+++ b/src/lib/__tests__/structured-data.test.ts
@@ -1,4 +1,6 @@
 import {
+  blogBreadcrumbSchema,
+  blogPostingSchema,
   breadcrumbSchema,
   itemListSchema,
   organizationSchema,
@@ -111,6 +113,52 @@ describe('structured-data', () => {
       expect(schema.itemListElement[2].item).toBe(
         'https://roadmapcol.com/tours/test'
       )
+    })
+  })
+
+  describe('blogBreadcrumbSchema', () => {
+    it('returns BreadcrumbList with Home, Blog and the post', () => {
+      const schema = blogBreadcrumbSchema('Test Post', 'test-post')
+      expect(schema['@type']).toBe('BreadcrumbList')
+      const [home, blog, post] = schema.itemListElement
+      expect(home.name).toBe('Home')
+      expect(blog.name).toBe('Blog')
+      expect(blog.item).toBe('https://roadmapcol.com/blog')
+      expect(post.name).toBe('Test Post')
+      expect(post.item).toBe('https://roadmapcol.com/blog/test-post')
+    })
+  })
+
+  describe('blogPostingSchema', () => {
+    const post = {
+      coverImage: 'https://example.com/cover.jpg',
+      date: '2026-01-15',
+      description: 'A great post',
+      slug: 'test-post',
+      title: 'Test Post',
+    }
+
+    it('returns BlogPosting schema with post data', () => {
+      const schema = blogPostingSchema(post)
+      expect(schema['@type']).toBe('BlogPosting')
+      expect(schema.headline).toBe('Test Post')
+      expect(schema.description).toBe('A great post')
+      expect(schema.image).toBe('https://example.com/cover.jpg')
+      expect(schema.datePublished).toBe('2026-01-15')
+    })
+
+    it('builds full url and mainEntityOfPage from slug', () => {
+      const schema = blogPostingSchema(post)
+      expect(schema.url).toBe('https://roadmapcol.com/blog/test-post')
+      expect(schema.mainEntityOfPage).toBe(
+        'https://roadmapcol.com/blog/test-post'
+      )
+    })
+
+    it('includes publisher with logo', () => {
+      const schema = blogPostingSchema(post)
+      expect(schema.publisher.name).toBe('Road Map Col')
+      expect(schema.publisher.logo.url).toContain('cloudinary.com')
     })
   })
 })

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -1,0 +1,57 @@
+import fs from 'fs'
+import matter from 'gray-matter'
+import path from 'path'
+import readingTime from 'reading-time'
+
+const BLOG_DIR = path.join(process.cwd(), 'src/content/blog')
+
+export interface BlogPostMeta {
+  coverImage: string
+  date: string
+  description: string
+  readingTime: string
+  relatedTourHref?: string
+  slug: string
+  tags: string[]
+  title: string
+}
+
+export interface BlogPost extends BlogPostMeta {
+  content: string
+}
+
+function readPost(slug: string): BlogPost {
+  const filePath = path.join(BLOG_DIR, `${slug}.md`)
+  const raw = fs.readFileSync(filePath, 'utf8')
+  const { content, data } = matter(raw)
+
+  return {
+    content,
+    coverImage: data.coverImage,
+    date: data.date,
+    description: data.description,
+    readingTime: readingTime(content).text,
+    relatedTourHref: data.relatedTourHref,
+    slug,
+    tags: data.tags,
+    title: data.title,
+  }
+}
+
+export function getAllPostSlugs(): string[] {
+  return fs
+    .readdirSync(BLOG_DIR)
+    .filter((file) => file.endsWith('.md'))
+    .map((file) => file.replace(/\.md$/, ''))
+}
+
+export function getPostBySlug(slug: string): BlogPost | null {
+  if (!getAllPostSlugs().includes(slug)) return null
+  return readPost(slug)
+}
+
+export function getAllPosts(): BlogPostMeta[] {
+  return getAllPostSlugs()
+    .map((slug) => readPost(slug))
+    .sort((a, b) => (a.date < b.date ? 1 : -1))
+}

--- a/src/lib/data.tsx
+++ b/src/lib/data.tsx
@@ -1,4 +1,4 @@
-import { Gift, Home, Info, Map, MapPin } from 'lucide-react'
+import { BookOpen, Gift, Home, Info, Map, MapPin } from 'lucide-react'
 
 export const HEADER_LINKS = [
   {
@@ -15,6 +15,11 @@ export const HEADER_LINKS = [
     label: 'Personalize your experience',
     href: '/personalize',
     icon: <MapPin />,
+  },
+  {
+    label: 'Blog',
+    href: '/blog',
+    icon: <BookOpen />,
   },
 ]
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,8 @@
+import { remark } from 'remark'
+import remarkGfm from 'remark-gfm'
+import remarkHtml from 'remark-html'
+
+export async function renderMarkdown(content: string): Promise<string> {
+  const result = await remark().use(remarkGfm).use(remarkHtml).process(content)
+  return result.toString()
+}

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -84,3 +84,55 @@ export function breadcrumbSchema(tourTitle: string, tourHref: string) {
     ],
   }
 }
+
+export function blogBreadcrumbSchema(postTitle: string, slug: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        item: BASE_URL,
+        name: 'Home',
+        position: 1,
+      },
+      {
+        '@type': 'ListItem',
+        item: `${BASE_URL}/blog`,
+        name: 'Blog',
+        position: 2,
+      },
+      {
+        '@type': 'ListItem',
+        item: `${BASE_URL}/blog/${slug}`,
+        name: postTitle,
+        position: 3,
+      },
+    ],
+  }
+}
+
+export function blogPostingSchema(post: {
+  coverImage: string
+  date: string
+  description: string
+  slug: string
+  title: string
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    author: { '@type': 'Organization', name: 'Road Map Col' },
+    datePublished: post.date,
+    description: post.description,
+    headline: post.title,
+    image: post.coverImage,
+    mainEntityOfPage: `${BASE_URL}/blog/${post.slug}`,
+    publisher: {
+      '@type': 'Organization',
+      logo: { '@type': 'ImageObject', url: LOGO_URL },
+      name: 'Road Map Col',
+    },
+    url: `${BASE_URL}/blog/${post.slug}`,
+  }
+}


### PR DESCRIPTION
## What and why
The site had zero content targeting informational or long-tail search
queries — only transactional tour pages. Aggressive keyword coverage
needs a content engine, not just metadata tweaks, so this PR adds a
full travel blog at `/blog` designed to rank for the searches people
actually run before booking a trip to Medellín/Antioquia.

## Changes
- New `/blog` (index) and `/blog/[slug]` (post) routes, statically generated
- 17 launch articles as Markdown files in `src/content/blog/` (no CMS/DB, git-versioned, consistent with the rest of the project's static-data pattern):
  - 8 posts map 1:1 to existing tours (Guatapé, Comuna 13, Jardín, MAVI Cartagena, Hacienda Nápoles, Paragliding, Salto del Buey, Orient Tour), each with a CTA linking to its tour page
  - 9 broader informational posts (safety, best time to visit, transportation, itineraries, Medellín vs Cartagena, packing list, food, day trips roundup, first-timer tips) targeting top-of-funnel search intent
- `src/lib/blog.ts`: content loader (`getAllPosts`, `getPostBySlug`, `getAllPostSlugs`) reading frontmatter via `gray-matter`
- `src/lib/markdown.ts`: renders post Markdown to HTML via `remark`/`remark-gfm`/`remark-html`
- `blogPostingSchema` and `blogBreadcrumbSchema` added to `structured-data.ts`, rendered as JSON-LD on every post
- Unique `title`/`description`/canonical per post and on `/blog`; `ItemList` JSON-LD on the blog index
- "Blog" added to `HEADER_LINKS` nav; blog routes added to `sitemap.ts`
- `.blog-content` CSS rules in `globals.css` style the rendered Markdown (headings, links, lists, blockquotes, tables)

## Type of change
- [ ] Bug fix (non-breaking, fixes an issue)
- [x] New feature (non-breaking, adds functionality)
- [ ] Chore / refactor (no behaviour change)
- [ ] Breaking change (existing functionality is affected)

## Test plan
- [x] `bun run lint`, `bun run type-check`, `bun run test:coverage` — all green, 100% coverage (186 tests)
- [x] `bun run build` — all 17 posts statically generated successfully
- [x] Verified in a real production server (`bun run start`) via curl: unique title/canonical per post, rendered headings/links/table/blockquote, `BlogPosting` + `BreadcrumbList` JSON-LD, CTA links to the correct tour, `/blog` nav link, all 17 posts present in `sitemap.xml`

## Notes for reviewer
- Originally implemented with `next-mdx-remote` (both the RSC and classic client APIs), but hit a genuine `next-mdx-remote` / React 19.0.0 / Next 16 incompatibility that made `next build` fail outright (`Cannot read properties of null (reading 'useState')` during static generation). Switched to plain Markdown (`remark`) instead — content doesn't use any custom JSX components, so this is simpler, has no client-side JS cost, and sidesteps the whole class of bug. Content files were renamed `.mdx` → `.md` to reflect that.
- Cover images for the 8 tour-specific posts reuse that tour's real photography. The 9 informational posts reuse existing tour/landing photos that are thematically close (no dedicated stock photography was available for topics like "packing list" or "safety") — worth uploading dedicated images via `/new-image` later if these posts get traction.
- Deliberately shipped 17 solid, differentiated articles rather than a much larger batch of thin pages — Google's spam policies penalize scaled, low-value content, so it's safer to validate quality/indexing on this batch before expanding further.
- Once merged and deployed, worth checking `check_indexing_issues` / `get_performance_overview` via the Search Console MCP in a week or two to see how the new pages are being crawled.