### PR TITLE
fix: prioritize first tour carousel image for LCP (#41)

### DIFF
--- a/src/components/ui/__tests__/tour-media-carousel.test.tsx
+++ b/src/components/ui/__tests__/tour-media-carousel.test.tsx
@@ -10,9 +10,13 @@ vi.mock('embla-carousel-react', () => ({
 }))
 
 vi.mock('next/image', () => ({
-  default: ({ alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+  default: ({
+    alt,
+    priority,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { priority?: boolean }) => (
     // eslint-disable-next-line @next/next/no-img-element
-    <img alt={alt} {...props} />
+    <img alt={alt} data-priority={priority ? 'true' : 'false'} {...props} />
   ),
 }))
 
@@ -67,6 +71,16 @@ describe('TourMediaCarousel', () => {
     render(<TourMediaCarousel items={imageItems} />)
     expect(screen.getByAltText('Image 1')).toBeInTheDocument()
     expect(screen.getByAltText('Image 2')).toBeInTheDocument()
+  })
+
+  it('marks the first image as priority and sets sizes on all images', () => {
+    render(<TourMediaCarousel items={imageItems} />)
+    const first = screen.getByAltText('Image 1')
+    const second = screen.getByAltText('Image 2')
+    expect(first).toHaveAttribute('data-priority', 'true')
+    expect(second).toHaveAttribute('data-priority', 'false')
+    expect(first).toHaveAttribute('sizes', '(max-width: 768px) 100vw, 640px')
+    expect(second).toHaveAttribute('sizes', '(max-width: 768px) 100vw, 640px')
   })
 
   it('renders video items — uses thumbnail when provided', () => {

--- a/src/components/ui/tour-media-carousel.tsx
+++ b/src/components/ui/tour-media-carousel.tsx
@@ -70,6 +70,8 @@ export function TourMediaCarousel({
                   alt={item.alt}
                   width={500}
                   height={500}
+                  priority={index === 0}
+                  sizes="(max-width: 768px) 100vw, 640px"
                   className="h-[400px] w-full object-cover"
                 />
               ) : (


### PR DESCRIPTION
## What and why
The first slide of the tour media carousel is the LCP element on every tour detail page, but it was lazy-loaded by default. This delays the fetch until after layout/JS and hurts LCP. Matching the home carousel pattern.

## Changes
- Add `priority={index === 0}` on first image in `tour-media-carousel.tsx`
- Add `sizes="(max-width: 768px) 100vw, 640px"` on carousel images
- Test that first image is priority and all images get `sizes`

## Type of change
- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Chore / refactor (no behaviour change)
- [ ] Breaking change (existing functionality is affected)

## Test plan
- [ ] Open any tour detail page (e.g. `/tours/guatape`) and confirm the first gallery image loads eagerly in Network (no lazy)
- [ ] Scroll carousel — subsequent slides still lazy-load
- [x] Run `bun test` — all tests pass
- [x] Run `bun run type-check` — no type errors

## Notes for reviewer
Base is `main` (not `develop`). `develop` was deleted as requested.

---
Closes #41