### PR TITLE
chore: drop develop exception from branch cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -7,9 +7,7 @@ on:
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
-    if: >
-      github.event.pull_request.head.ref != 'develop' &&
-      github.event.pull_request.head.ref != 'main'
+    if: github.event.pull_request.head.ref != 'main'
     steps:
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## What and why
`main` is now branch-protected and `delete_branch_on_merge` is enabled. The cleanup workflow still deleted branches on PR close (including closed without merge); it still referenced `develop`, which no longer exists.

## Changes
- Remove `develop` from the cleanup workflow branch exception list

## Type of change
- [x] Chore / refactor (no behaviour change)

## Test plan
- [ ] Merge any PR and confirm the head branch is auto-deleted
- [ ] Close a PR without merging and confirm cleanup deletes the branch

## Notes for reviewer
Repo settings already applied via API (no code change needed for those):
- `delete_branch_on_merge: true`
- `main` protection: require PR, enforce admins, require CI checks (lint, typecheck, Unit tests, Coverage)