### PR TITLE
fix: cap Cloudinary image widths via imgUrl (#40)

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { JsonLd } from '@/components/json-ld'
 import { Button } from '@/components/ui/button'
 import { PostTitle } from '@/components/ui/typography/typography'
 import { getAllPostSlugs, getPostBySlug } from '@/lib/blog'
+import { IMG_WIDTH_DETAIL, IMG_WIDTH_OG, imgUrl } from '@/lib/cloudinary'
 import { renderMarkdown } from '@/lib/markdown'
 import { blogBreadcrumbSchema, blogPostingSchema } from '@/lib/structured-data'
 import type { Metadata } from 'next'
@@ -26,7 +27,14 @@ export async function generateMetadata({
   return {
     alternates: { canonical: `/blog/${post.slug}` },
     description: post.description,
-    openGraph: { images: [{ alt: post.title, url: post.coverImage }] },
+    openGraph: {
+      images: [
+        {
+          alt: post.title,
+          url: imgUrl(post.coverImage, IMG_WIDTH_OG),
+        },
+      ],
+    },
     title: post.title,
   }
 }
@@ -43,7 +51,7 @@ export default async function BlogPostPage({ params }: PageProps) {
       <JsonLd data={blogBreadcrumbSchema(post.title, post.slug)} />
       <div className="relative h-64 w-full overflow-hidden rounded-md md:h-96">
         <Image
-          src={post.coverImage}
+          src={imgUrl(post.coverImage, IMG_WIDTH_DETAIL)}
           alt={post.title}
           fill
           priority

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import { JsonLd } from '@/components/json-ld'
 import { Title } from '@/components/ui/typography/typography'
 import { getAllPosts } from '@/lib/blog'
+import { IMG_WIDTH_CARD, imgUrl } from '@/lib/cloudinary'
 import { itemListSchema } from '@/lib/structured-data'
 import type { Metadata } from 'next'
 import Image from 'next/image'
@@ -40,7 +41,7 @@ export default function BlogIndex() {
           >
             <div className="relative h-48 w-full overflow-hidden">
               <Image
-                src={post.coverImage}
+                src={imgUrl(post.coverImage, IMG_WIDTH_CARD)}
                 alt={post.title}
                 fill
                 className="object-cover transition-transform duration-300 group-hover:scale-105"

--- a/src/app/tours/[name]/page.tsx
+++ b/src/app/tours/[name]/page.tsx
@@ -1,4 +1,5 @@
 import { JsonLd } from '@/components/json-ld'
+import { IMG_WIDTH_OG, imgUrl } from '@/lib/cloudinary'
 import { TOURS } from '@/lib/data'
 import { breadcrumbSchema, touristTripSchema } from '@/lib/structured-data'
 import type { Metadata } from 'next'
@@ -21,7 +22,9 @@ export async function generateMetadata({
   return {
     alternates: { canonical: tour.href },
     description: tour.description,
-    openGraph: { images: [{ alt: tour.title, url: tour.image }] },
+    openGraph: {
+      images: [{ alt: tour.title, url: imgUrl(tour.image, IMG_WIDTH_OG) }],
+    },
     title: tour.title,
   }
 }

--- a/src/app/tours/[name]/tour-client.tsx
+++ b/src/app/tours/[name]/tour-client.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { StarRating } from '@/components/ui/star-rating'
 import { TourMediaCarousel } from '@/components/ui/tour-media-carousel'
-import { imgUrl } from '@/lib/cloudinary'
+import { IMG_WIDTH_CARD, IMG_WIDTH_DETAIL, imgUrl } from '@/lib/cloudinary'
 import { CONTACT } from '@/lib/data'
 import { images } from '@/lib/images'
 import { ArrowLeft, Check, Clock, MapPin } from 'lucide-react'
@@ -86,7 +86,7 @@ export default function TourClient({ tour }: { tour: Tour }) {
             <TourMediaCarousel items={tour.images} />
           ) : (
             <Image
-              src={imgUrl(tour.image)}
+              src={imgUrl(tour.image, IMG_WIDTH_DETAIL)}
               alt={tour.place}
               width={500}
               height={500}
@@ -130,7 +130,7 @@ export default function TourClient({ tour }: { tour: Tour }) {
                 className="mx-auto flex w-11/12 flex-col py-0 md:w-full md:flex-row"
               >
                 <Image
-                  src={imgUrl(activity.image)}
+                  src={imgUrl(activity.image, IMG_WIDTH_CARD)}
                   alt={activity.title}
                   width={200}
                   height={200}

--- a/src/components/tour-card.tsx
+++ b/src/components/tour-card.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { StarRating } from '@/components/ui/star-rating'
-import { blurDataUrl, imgUrl } from '@/lib/cloudinary'
+import { IMG_WIDTH_CARD, blurDataUrl, imgUrl } from '@/lib/cloudinary'
 import { ArrowRight, Clock, MapPin } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -26,7 +26,7 @@ export function TourCard({
       <Card className="flex h-full flex-col pt-0 transition-shadow duration-200 hover:shadow-md">
         <CardHeader className="overflow-hidden rounded-t-[14px] px-0 pt-0">
           <Image
-            src={imgUrl(tour.image)}
+            src={imgUrl(tour.image, IMG_WIDTH_CARD)}
             alt={tour.place}
             width={500}
             height={500}

--- a/src/components/ui/carousel-home.tsx
+++ b/src/components/ui/carousel-home.tsx
@@ -10,6 +10,7 @@ import {
   CarouselPrevious,
 } from '@/components/ui/carousel'
 import { TitleCard } from '@/components/ui/typography/typography'
+import { imgUrl } from '@/lib/cloudinary'
 import { LANDING_LINKS } from '@/lib/data'
 import Autoplay from 'embla-carousel-autoplay'
 import Image from 'next/image'
@@ -55,7 +56,7 @@ export function CarouselHome() {
           >
             {index === 0 ? (
               <Image
-                src={item.image}
+                src={imgUrl(item.image)}
                 alt={item.title}
                 fill
                 priority
@@ -63,7 +64,7 @@ export function CarouselHome() {
               />
             ) : (
               <Image
-                src={item.image}
+                src={imgUrl(item.image)}
                 alt={item.title}
                 fill
                 loading="lazy"

--- a/src/components/ui/tour-media-carousel.tsx
+++ b/src/components/ui/tour-media-carousel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { imgUrl, videoPoster } from '@/lib/cloudinary'
+import { IMG_WIDTH_DETAIL, imgUrl, videoPoster } from '@/lib/cloudinary'
 import { cn } from '@/lib/utils'
 import useEmblaCarousel from 'embla-carousel-react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
@@ -66,7 +66,7 @@ export function TourMediaCarousel({
             >
               {item.type === 'image' ? (
                 <Image
-                  src={imgUrl(item.url)}
+                  src={imgUrl(item.url, IMG_WIDTH_DETAIL)}
                   alt={item.alt}
                   width={500}
                   height={500}

--- a/src/lib/__tests__/cloudinary.test.ts
+++ b/src/lib/__tests__/cloudinary.test.ts
@@ -1,10 +1,36 @@
-import { blurDataUrl, imgUrl, videoPoster } from '@/lib/cloudinary'
+import {
+  IMG_WIDTH_CARD,
+  blurDataUrl,
+  imgUrl,
+  videoPoster,
+} from '@/lib/cloudinary'
 
 describe('imgUrl', () => {
-  it('injects f_auto,q_auto into a Cloudinary upload URL', () => {
+  it('injects f_auto,q_auto and a default width cap', () => {
     const url = 'https://res.cloudinary.com/demo/image/upload/sample.jpg'
     expect(imgUrl(url)).toBe(
-      'https://res.cloudinary.com/demo/image/upload/f_auto,q_auto/sample.jpg'
+      'https://res.cloudinary.com/demo/image/upload/f_auto,q_auto,w_1600,c_limit/sample.jpg'
+    )
+  })
+
+  it('accepts a custom width', () => {
+    const url = 'https://res.cloudinary.com/demo/image/upload/sample.jpg'
+    expect(imgUrl(url, IMG_WIDTH_CARD)).toBe(
+      'https://res.cloudinary.com/demo/image/upload/f_auto,q_auto,w_800,c_limit/sample.jpg'
+    )
+  })
+
+  it('does not double-add w_ when the URL already has a width', () => {
+    const url =
+      'https://res.cloudinary.com/demo/image/upload/w_1920,q_auto,f_auto/v1/sample.jpg'
+    expect(imgUrl(url)).toBe(url)
+  })
+
+  it('adds f_auto,q_auto when width exists but format/quality do not', () => {
+    const url =
+      'https://res.cloudinary.com/demo/image/upload/w_1000,c_fill/v1/sample.jpg'
+    expect(imgUrl(url)).toBe(
+      'https://res.cloudinary.com/demo/image/upload/f_auto,q_auto/w_1000,c_fill/v1/sample.jpg'
     )
   })
 

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -1,5 +1,31 @@
-export function imgUrl(url: string): string {
-  return url.replace('/upload/', '/upload/f_auto,q_auto/')
+/** Default max width for detail/gallery images (retina-friendly). */
+export const IMG_WIDTH_DETAIL = 1600
+/** Max width for card/thumbnail images. */
+export const IMG_WIDTH_CARD = 800
+/** Max width for OG/social preview images. */
+export const IMG_WIDTH_OG = 1200
+/** Max width for small icons/logos. */
+export const IMG_WIDTH_ICON = 200
+
+/**
+ * Inject Cloudinary delivery transforms: format/quality auto + width cap.
+ * Skips adding another `w_` when the URL already has one.
+ */
+export function imgUrl(url: string, width: number = IMG_WIDTH_DETAIL): string {
+  if (!url.includes('/upload/')) return url
+
+  // First path segment after /upload/ already sets a width — keep it.
+  if (/\/upload\/[^/]*\bw_\d+/.test(url)) {
+    if (
+      /\/upload\/[^/]*\bf_auto\b/.test(url) &&
+      /\/upload\/[^/]*\bq_auto\b/.test(url)
+    ) {
+      return url
+    }
+    return url.replace('/upload/', '/upload/f_auto,q_auto/')
+  }
+
+  return url.replace('/upload/', `/upload/f_auto,q_auto,w_${width},c_limit/`)
 }
 
 export function videoPoster(url: string): string {

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,16 +1,20 @@
-import { imgUrl } from './cloudinary'
+import { IMG_WIDTH_ICON, imgUrl } from './cloudinary'
 
 export const images = {
   instagram: imgUrl(
-    'https://res.cloudinary.com/lesteban/image/upload/v1749335595/Logos/instagram.png'
+    'https://res.cloudinary.com/lesteban/image/upload/v1749335595/Logos/instagram.png',
+    IMG_WIDTH_ICON
   ),
   logo: imgUrl(
-    'https://res.cloudinary.com/lesteban/image/upload/v1748229585/roadmap/road_map_sin_fondo_atjeji.png'
+    'https://res.cloudinary.com/lesteban/image/upload/v1748229585/roadmap/road_map_sin_fondo_atjeji.png',
+    IMG_WIDTH_ICON
   ),
   tiktok: imgUrl(
-    'https://res.cloudinary.com/lesteban/image/upload/v1749335595/Logos/tiktok.png'
+    'https://res.cloudinary.com/lesteban/image/upload/v1749335595/Logos/tiktok.png',
+    IMG_WIDTH_ICON
   ),
   whatsapp: imgUrl(
-    'https://res.cloudinary.com/lesteban/image/upload/v1749335595/Logos/whatsapp.png'
+    'https://res.cloudinary.com/lesteban/image/upload/v1749335595/Logos/whatsapp.png',
+    IMG_WIDTH_ICON
   ),
 }

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,8 +1,11 @@
+import { IMG_WIDTH_ICON, IMG_WIDTH_OG, imgUrl } from './cloudinary'
 import { CONTACT } from './data'
 
 const BASE_URL = 'https://roadmapcol.com'
-const LOGO_URL =
-  'https://res.cloudinary.com/lesteban/image/upload/v1748229585/roadmap/road_map_sin_fondo_atjeji.png'
+const LOGO_URL = imgUrl(
+  'https://res.cloudinary.com/lesteban/image/upload/v1748229585/roadmap/road_map_sin_fondo_atjeji.png',
+  IMG_WIDTH_ICON
+)
 
 export function organizationSchema() {
   return {
@@ -32,7 +35,7 @@ export function touristTripSchema(tour: {
     '@context': 'https://schema.org',
     '@type': 'TouristTrip',
     description: tour.description,
-    image: tour.image,
+    image: imgUrl(tour.image, IMG_WIDTH_OG),
     name: tour.title,
     offers: {
       '@type': 'Offer',
@@ -126,7 +129,7 @@ export function blogPostingSchema(post: {
     datePublished: post.date,
     description: post.description,
     headline: post.title,
-    image: post.coverImage,
+    image: imgUrl(post.coverImage, IMG_WIDTH_OG),
     mainEntityOfPage: `${BASE_URL}/blog/${post.slug}`,
     publisher: {
       '@type': 'Organization',


### PR DESCRIPTION
## What and why
Tour/blog images pointed at multi-MB Cloudinary originals. `next/image` had to download 2–5 MB sources before resizing, making first loads slow. Cap delivery widths at the CDN so the optimizer (and browsers) never fetch uncapped originals.

## Changes
- Extend `imgUrl(url, width?)` to inject `f_auto,q_auto,w_{n},c_limit` (default 1600); skip double-`w_` when already present
- Export width constants: card 800, detail 1600, OG 1200, icon 200
- Apply card width on `TourCard` and activity images
- Apply detail width on tour gallery carousel + blog post covers
- Apply OG width on tour/blog metadata and JSON-LD
- Apply icon width on logo/social assets in `images.ts`
- Route home carousel and blog index covers through `imgUrl`
- Expand unit tests for width / existing-transform cases

## Type of change
- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Chore / refactor (no behaviour change)
- [ ] Breaking change (existing functionality is affected)

## Test plan
- [ ] Open `/tours` — card image URLs include `w_800,c_limit`
- [ ] Open a tour detail gallery — images include `w_1600,c_limit`
- [ ] Open `/blog` and a post — covers are width-capped
- [x] Run `bun test` — all tests pass (191)
- [x] Run `bun run type-check` — no type errors
- [x] Run `bun run test:coverage` — 100%

## Notes for reviewer
URLs that already declare `w_*` (e.g. landing hero `w_1920`) are left unchanged aside from ensuring `f_auto,q_auto` when missing.

---
Closes #40