### PR TITLE
fix: pre-render tour detail pages with generateStaticParams (#39)

### DIFF
--- a/src/app/tours/[name]/page.tsx
+++ b/src/app/tours/[name]/page.tsx
@@ -11,6 +11,14 @@ interface PageProps {
   params: Promise<{ name: string }>
 }
 
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return TOURS.map((tour) => ({
+    name: tour.href.replace(/^\/tours\//, ''),
+  }))
+}
+
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {

--- a/src/app/tours/__tests__/tour-page.test.tsx
+++ b/src/app/tours/__tests__/tour-page.test.tsx
@@ -1,4 +1,8 @@
-import TourPage, { generateMetadata } from '@/app/tours/[name]/page'
+import TourPage, {
+  dynamicParams,
+  generateMetadata,
+  generateStaticParams,
+} from '@/app/tours/[name]/page'
 import { render, screen } from '@testing-library/react'
 import { notFound } from 'next/navigation'
 
@@ -67,5 +71,17 @@ describe('generateMetadata', () => {
       params: Promise.resolve({ name: 'unknown' }),
     })
     expect(result).toEqual({})
+  })
+})
+
+describe('generateStaticParams', () => {
+  it('returns a name param for every tour', () => {
+    expect(generateStaticParams()).toEqual([{ name: 'test-tour' }])
+  })
+})
+
+describe('dynamicParams', () => {
+  it('is false so unknown slugs 404 at the edge', () => {
+    expect(dynamicParams).toBe(false)
   })
 })


### PR DESCRIPTION
## What and why
Tour detail pages were server-rendered on demand (`ƒ`), so every visit hit a serverless function. All tour data is static, so these pages should be SSG and served from the CDN like blog posts.

## Changes
- Add `generateStaticParams()` in `tours/[name]/page.tsx` from `TOURS` hrefs
- Set `dynamicParams = false` so unknown slugs 404 at the edge
- Tests for both exports

## Type of change
- [x] Bug fix (non-breaking, fixes an issue)
- [ ] New feature (non-breaking, adds functionality)
- [ ] Chore / refactor (no behaviour change)
- [ ] Breaking change (existing functionality is affected)

## Test plan
- [x] `bun run build` shows `● /tours/[name]` with all tour paths pre-rendered
- [x] Unknown slug still calls `notFound` in unit tests
- [x] Run `bun test` — all tests pass
- [x] Run `bun run type-check` — no type errors

## Notes for reviewer
Build output before: `ƒ /tours/[name]`. After: `● /tours/[name]` with 8 paths.

---
Closes #39