### PR TITLE
feat: full media in carousels and branded OG/Twitter images

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,8 +2,9 @@ import { JsonLd } from '@/components/json-ld'
 import { Button } from '@/components/ui/button'
 import { PostTitle } from '@/components/ui/typography/typography'
 import { getAllPostSlugs, getPostBySlug } from '@/lib/blog'
-import { IMG_WIDTH_DETAIL, IMG_WIDTH_OG, imgUrl } from '@/lib/cloudinary'
+import { IMG_WIDTH_DETAIL, imgUrl } from '@/lib/cloudinary'
 import { renderMarkdown } from '@/lib/markdown'
+import { socialMetadata } from '@/lib/og'
 import { blogBreadcrumbSchema, blogPostingSchema } from '@/lib/structured-data'
 import type { Metadata } from 'next'
 import Image from 'next/image'
@@ -27,15 +28,14 @@ export async function generateMetadata({
   return {
     alternates: { canonical: `/blog/${post.slug}` },
     description: post.description,
-    openGraph: {
-      images: [
-        {
-          alt: post.title,
-          url: imgUrl(post.coverImage, IMG_WIDTH_OG),
-        },
-      ],
-    },
     title: post.title,
+    ...socialMetadata({
+      alt: post.title,
+      description: post.description,
+      imageUrl: post.coverImage,
+      title: post.title,
+      url: `https://roadmapcol.com/blog/${post.slug}`,
+    }),
   }
 }
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -2,16 +2,24 @@ import { JsonLd } from '@/components/json-ld'
 import { Title } from '@/components/ui/typography/typography'
 import { getAllPosts } from '@/lib/blog'
 import { IMG_WIDTH_CARD, imgUrl } from '@/lib/cloudinary'
+import { socialMetadata } from '@/lib/og'
 import { itemListSchema } from '@/lib/structured-data'
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 
+const blogDescription =
+  'Travel guides, tips and stories about Medellín, Antioquia and Colombia — safety, itineraries, food, and our favorite day trips.'
+
 export const metadata: Metadata = {
   alternates: { canonical: '/blog' },
-  description:
-    'Travel guides, tips and stories about Medellín, Antioquia and Colombia — safety, itineraries, food, and our favorite day trips.',
+  description: blogDescription,
   title: 'Travel Blog',
+  ...socialMetadata({
+    description: blogDescription,
+    title: 'Travel Blog',
+    url: 'https://roadmapcol.com/blog',
+  }),
 }
 
 export default function BlogIndex() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Footer from '@/components/ui/footer'
 import Header from '@/components/ui/header'
 import { CONTACT } from '@/lib/data'
 import { images } from '@/lib/images'
+import { DEFAULT_OG_IMAGE, OG_HEIGHT, OG_WIDTH } from '@/lib/og'
 import { organizationSchema } from '@/lib/structured-data'
 import { Analytics } from '@vercel/analytics/next'
 import type { Metadata } from 'next'
@@ -28,18 +29,23 @@ const geistMono = Geist_Mono({
 const siteDescription =
   'Discover unforgettable tours in Medellín, Antioquia and Colombia. Adventure, culture and nature experiences designed for you.'
 const siteTitle = 'Road Map Col — Tours in Colombia'
-const ogImageUrl =
-  'https://res.cloudinary.com/lesteban/image/upload/w_1200,h_630,c_pad,b_white/v1748229585/roadmap/road_map_sin_fondo_atjeji.png'
 
 export const metadata: Metadata = {
   description: siteDescription,
   metadataBase: new URL('https://roadmapcol.com'),
   openGraph: {
+    description: siteDescription,
     images: [
-      { alt: 'Road Map Col', height: 630, url: ogImageUrl, width: 1200 },
+      {
+        alt: 'Road Map Col',
+        height: OG_HEIGHT,
+        url: DEFAULT_OG_IMAGE,
+        width: OG_WIDTH,
+      },
     ],
     locale: 'en_US',
     siteName: 'Road Map Col',
+    title: siteTitle,
     type: 'website',
     url: 'https://roadmapcol.com',
   },
@@ -50,7 +56,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     description: siteDescription,
-    images: [ogImageUrl],
+    images: [DEFAULT_OG_IMAGE],
     title: siteTitle,
   },
   verification: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,19 @@
 import { Testimonials } from '@/components/testimonials'
 import { CarouselHome } from '@/components/ui/carousel-home'
 import { Title } from '@/components/ui/typography/typography'
+import { socialMetadata } from '@/lib/og'
 import type { Metadata } from 'next'
+
+const homeDescription =
+  'Discover unforgettable tours in Medellín, Antioquia and Colombia. Adventure, culture and nature experiences designed for you.'
 
 export const metadata: Metadata = {
   alternates: { canonical: '/' },
+  ...socialMetadata({
+    description: homeDescription,
+    title: 'Road Map Col — Tours in Colombia',
+    url: 'https://roadmapcol.com',
+  }),
 }
 
 export default function Home() {

--- a/src/app/personalize/page.tsx
+++ b/src/app/personalize/page.tsx
@@ -1,12 +1,20 @@
+import { socialMetadata } from '@/lib/og'
 import type { Metadata } from 'next'
 
 import PersonalizeClient from './personalize-client'
 
+const personalizeDescription =
+  'Tell us your travel dates, budget and interests and we will design a private, personalized tour itinerary across Colombia just for you.'
+
 export const metadata: Metadata = {
   alternates: { canonical: '/personalize' },
-  description:
-    'Tell us your travel dates, budget and interests and we will design a private, personalized tour itinerary across Colombia just for you.',
+  description: personalizeDescription,
   title: 'Personalize your tour',
+  ...socialMetadata({
+    description: personalizeDescription,
+    title: 'Personalize your tour',
+    url: 'https://roadmapcol.com/personalize',
+  }),
 }
 
 export default function PersonalizePage() {

--- a/src/app/tours/[name]/page.tsx
+++ b/src/app/tours/[name]/page.tsx
@@ -1,6 +1,6 @@
 import { JsonLd } from '@/components/json-ld'
-import { IMG_WIDTH_OG, imgUrl } from '@/lib/cloudinary'
 import { TOURS } from '@/lib/data'
+import { socialMetadata } from '@/lib/og'
 import { breadcrumbSchema, touristTripSchema } from '@/lib/structured-data'
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
@@ -30,10 +30,14 @@ export async function generateMetadata({
   return {
     alternates: { canonical: tour.href },
     description: tour.description,
-    openGraph: {
-      images: [{ alt: tour.title, url: imgUrl(tour.image, IMG_WIDTH_OG) }],
-    },
     title: tour.title,
+    ...socialMetadata({
+      alt: tour.title,
+      description: tour.description,
+      imageUrl: tour.image,
+      title: tour.title,
+      url: `https://roadmapcol.com${tour.href}`,
+    }),
   }
 }
 

--- a/src/app/tours/__tests__/tour-page.test.tsx
+++ b/src/app/tours/__tests__/tour-page.test.tsx
@@ -64,6 +64,8 @@ describe('generateMetadata', () => {
     expect(result.title).toBe('Test Tour')
     expect(result.description).toBe('Test description')
     expect(result.alternates?.canonical).toBe('/tours/test-tour')
+    expect(result.twitter).toMatchObject({ card: 'summary_large_image' })
+    expect(result.openGraph?.images).toBeDefined()
   })
 
   it('returns empty object for an unknown tour', async () => {

--- a/src/app/tours/page.tsx
+++ b/src/app/tours/page.tsx
@@ -2,14 +2,22 @@ import { JsonLd } from '@/components/json-ld'
 import { TourCard } from '@/components/tour-card'
 import { Title } from '@/components/ui/typography/typography'
 import { TOURS } from '@/lib/data'
+import { socialMetadata } from '@/lib/og'
 import { itemListSchema } from '@/lib/structured-data'
 import type { Metadata } from 'next'
 
+const toursDescription =
+  'Browse our full catalogue of tours across Medellín, Guatapé, Jardín, Cartagena and the rest of Antioquia and Colombia — adventure, culture, nature and gastronomy experiences for every traveler.'
+
 export const metadata: Metadata = {
   alternates: { canonical: '/tours' },
-  description:
-    'Browse our full catalogue of tours across Medellín, Guatapé, Jardín, Cartagena and the rest of Antioquia and Colombia — adventure, culture, nature and gastronomy experiences for every traveler.',
+  description: toursDescription,
   title: 'Tours in Colombia',
+  ...socialMetadata({
+    description: toursDescription,
+    title: 'Tours in Colombia',
+    url: 'https://roadmapcol.com/tours',
+  }),
 }
 
 export default function Tours() {

--- a/src/components/ui/__tests__/tour-media-carousel.test.tsx
+++ b/src/components/ui/__tests__/tour-media-carousel.test.tsx
@@ -83,6 +83,14 @@ describe('TourMediaCarousel', () => {
     expect(second).toHaveAttribute('sizes', '(max-width: 768px) 100vw, 640px')
   })
 
+  it('uses object-contain so vertical media is fully visible', () => {
+    render(<TourMediaCarousel items={imageItems} />)
+    expect(screen.getByAltText('Image 1').className).toContain('object-contain')
+    render(<TourMediaCarousel items={videoItems} />)
+    const video = document.querySelector('video')
+    expect(video?.className).toContain('object-contain')
+  })
+
   it('renders video items — uses thumbnail when provided', () => {
     render(<TourMediaCarousel items={videoItems} />)
     const videos = document.querySelectorAll('video')

--- a/src/components/ui/carousel-home.tsx
+++ b/src/components/ui/carousel-home.tsx
@@ -1,18 +1,12 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
-import {
-  Carousel,
-  type CarouselApi,
-  CarouselContent,
-  CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
-} from '@/components/ui/carousel'
 import { TitleCard } from '@/components/ui/typography/typography'
 import { imgUrl } from '@/lib/cloudinary'
 import { LANDING_LINKS } from '@/lib/data'
 import Autoplay from 'embla-carousel-autoplay'
+import useEmblaCarousel from 'embla-carousel-react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import * as React from 'react'
@@ -22,77 +16,93 @@ import { Card, CardContent, CardHeader } from './card'
 
 export function CarouselHome() {
   const router = useRouter()
-  const [api, setApi] = React.useState<CarouselApi>()
   const autoplay = React.useMemo(
     () => Autoplay({ delay: 4000, stopOnInteraction: false }),
     []
   )
+  const [emblaRef, emblaApi] = useEmblaCarousel(
+    { align: 'start', loop: true },
+    [autoplay]
+  )
 
   const handlePrevious = () => {
-    api?.scrollPrev()
+    emblaApi?.scrollPrev()
     autoplay.reset()
   }
 
   const handleNext = () => {
-    api?.scrollNext()
+    emblaApi?.scrollNext()
     autoplay.reset()
   }
 
   return (
-    <Carousel
-      setApi={setApi}
-      opts={{
-        align: 'start',
-        loop: true,
-      }}
-      plugins={[autoplay]}
-      className="relative mt-14 h-[calc(100vh-3.5rem)] w-full"
-    >
-      <CarouselContent className="ml-0 h-full">
-        {LANDING_LINKS.map((item, index) => (
-          <CarouselItem
-            key={index}
-            className="relative h-[calc(100vh-3.5rem)] basis-full overflow-hidden pl-0"
-          >
-            <Image
-              src={imgUrl(item.image)}
-              alt={item.title}
-              fill
-              priority={index === 0}
-              loading={index === 0 ? undefined : 'lazy'}
-              sizes="100vw"
-              className="object-cover"
-            />
-            <div className="absolute inset-0 flex items-center justify-center">
-              <Card className="relative w-10/12 bg-white/90 shadow-lg backdrop-blur-sm md:w-xl">
-                <CardHeader className="flex flex-col items-center justify-center">
-                  <Badge className={`${item.chipColor} mx-auto text-black`}>
-                    {item.chipIcon}
-                    {item.chip}
-                  </Badge>
-                  <TitleCard>{item.title}</TitleCard>
-                  <p className="text-center text-xl font-bold">
-                    {item.subtitle}
-                  </p>
-                </CardHeader>
-                <CardContent className="flex flex-col items-center justify-center gap-4">
-                  <p className="text-center">{item.description}</p>
-                  <Button
-                    className="mx-auto w-full"
-                    onClick={() => {
-                      router.push(item.href)
-                    }}
-                  >
-                    {item.button}
-                  </Button>
-                </CardContent>
-              </Card>
+    <section className="relative mt-14 h-[calc(100dvh-3.5rem)] w-full">
+      <div className="h-full w-full overflow-hidden" ref={emblaRef}>
+        <div className="flex h-full touch-pan-y">
+          {LANDING_LINKS.map((item, index) => (
+            <div
+              key={index}
+              className="relative h-full min-w-0 shrink-0 grow-0 basis-full"
+            >
+              <Image
+                src={imgUrl(item.image)}
+                alt={item.title}
+                fill
+                priority={index === 0}
+                loading={index === 0 ? undefined : 'lazy'}
+                sizes="100vw"
+                className="object-cover object-center"
+              />
+              <div className="absolute inset-0 z-10 flex items-center justify-center">
+                <Card className="w-10/12 bg-white/90 shadow-lg backdrop-blur-sm md:w-xl">
+                  <CardHeader className="flex flex-col items-center justify-center">
+                    <Badge className={`${item.chipColor} mx-auto text-black`}>
+                      {item.chipIcon}
+                      {item.chip}
+                    </Badge>
+                    <TitleCard>{item.title}</TitleCard>
+                    <p className="text-center text-xl font-bold">
+                      {item.subtitle}
+                    </p>
+                  </CardHeader>
+                  <CardContent className="flex flex-col items-center justify-center gap-4">
+                    <p className="text-center">{item.description}</p>
+                    <Button
+                      className="mx-auto w-full"
+                      onClick={() => {
+                        router.push(item.href)
+                      }}
+                    >
+                      {item.button}
+                    </Button>
+                  </CardContent>
+                </Card>
+              </div>
             </div>
-          </CarouselItem>
-        ))}
-      </CarouselContent>
-      <CarouselPrevious className="absolute left-2" onClick={handlePrevious} />
-      <CarouselNext className="absolute right-6" onClick={handleNext} />
-    </Carousel>
+          ))}
+        </div>
+      </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        onClick={handlePrevious}
+        className="absolute top-1/2 left-2 z-20 size-8 -translate-y-1/2 rounded-full"
+      >
+        <ChevronLeft />
+        <span className="sr-only">Previous slide</span>
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        onClick={handleNext}
+        className="absolute top-1/2 right-6 z-20 size-8 -translate-y-1/2 rounded-full"
+      >
+        <ChevronRight />
+        <span className="sr-only">Next slide</span>
+      </Button>
+    </section>
   )
 }

--- a/src/components/ui/carousel-home.tsx
+++ b/src/components/ui/carousel-home.tsx
@@ -54,23 +54,25 @@ export function CarouselHome() {
             key={index}
             className="relative flex h-[calc(100vh-3.5rem)] w-full items-center justify-center overflow-hidden pl-0"
           >
-            {index === 0 ? (
-              <Image
-                src={imgUrl(item.image)}
-                alt={item.title}
-                fill
-                priority
-                className="object-cover"
-              />
-            ) : (
-              <Image
-                src={imgUrl(item.image)}
-                alt={item.title}
-                fill
-                loading="lazy"
-                className="object-cover"
-              />
-            )}
+            <div className="absolute inset-0 bg-neutral-900">
+              {index === 0 ? (
+                <Image
+                  src={imgUrl(item.image)}
+                  alt={item.title}
+                  fill
+                  priority
+                  className="object-contain"
+                />
+              ) : (
+                <Image
+                  src={imgUrl(item.image)}
+                  alt={item.title}
+                  fill
+                  loading="lazy"
+                  className="object-contain"
+                />
+              )}
+            </div>
             <Card className="relative w-10/12 bg-white/90 shadow-lg backdrop-blur-sm md:w-xl">
               <CardHeader className="flex flex-col items-center justify-center">
                 <Badge className={`${item.chipColor} mx-auto text-black`}>

--- a/src/components/ui/carousel-home.tsx
+++ b/src/components/ui/carousel-home.tsx
@@ -46,52 +46,48 @@ export function CarouselHome() {
         loop: true,
       }}
       plugins={[autoplay]}
-      className="mt-14 flex h-[calc(100vh-3.5rem)] w-screen flex-col items-center justify-center"
+      className="relative mt-14 h-[calc(100vh-3.5rem)] w-full"
     >
-      <CarouselContent className="mx-0 w-screen px-0">
+      <CarouselContent className="ml-0 h-full">
         {LANDING_LINKS.map((item, index) => (
           <CarouselItem
             key={index}
-            className="relative flex h-[calc(100vh-3.5rem)] w-full items-center justify-center overflow-hidden pl-0"
+            className="relative h-[calc(100vh-3.5rem)] basis-full overflow-hidden pl-0"
           >
-            {index === 0 ? (
-              <Image
-                src={imgUrl(item.image)}
-                alt={item.title}
-                fill
-                priority
-                className="object-cover"
-              />
-            ) : (
-              <Image
-                src={imgUrl(item.image)}
-                alt={item.title}
-                fill
-                loading="lazy"
-                className="object-cover"
-              />
-            )}
-            <Card className="relative w-10/12 bg-white/90 shadow-lg backdrop-blur-sm md:w-xl">
-              <CardHeader className="flex flex-col items-center justify-center">
-                <Badge className={`${item.chipColor} mx-auto text-black`}>
-                  {item.chipIcon}
-                  {item.chip}
-                </Badge>
-                <TitleCard>{item.title}</TitleCard>
-                <p className="text-center text-xl font-bold">{item.subtitle}</p>
-              </CardHeader>
-              <CardContent className="flex flex-col items-center justify-center gap-4">
-                <p className="text-center">{item.description}</p>
-                <Button
-                  className="mx-auto w-full"
-                  onClick={() => {
-                    router.push(item.href)
-                  }}
-                >
-                  {item.button}
-                </Button>
-              </CardContent>
-            </Card>
+            <Image
+              src={imgUrl(item.image)}
+              alt={item.title}
+              fill
+              priority={index === 0}
+              loading={index === 0 ? undefined : 'lazy'}
+              sizes="100vw"
+              className="object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center">
+              <Card className="relative w-10/12 bg-white/90 shadow-lg backdrop-blur-sm md:w-xl">
+                <CardHeader className="flex flex-col items-center justify-center">
+                  <Badge className={`${item.chipColor} mx-auto text-black`}>
+                    {item.chipIcon}
+                    {item.chip}
+                  </Badge>
+                  <TitleCard>{item.title}</TitleCard>
+                  <p className="text-center text-xl font-bold">
+                    {item.subtitle}
+                  </p>
+                </CardHeader>
+                <CardContent className="flex flex-col items-center justify-center gap-4">
+                  <p className="text-center">{item.description}</p>
+                  <Button
+                    className="mx-auto w-full"
+                    onClick={() => {
+                      router.push(item.href)
+                    }}
+                  >
+                    {item.button}
+                  </Button>
+                </CardContent>
+              </Card>
+            </div>
           </CarouselItem>
         ))}
       </CarouselContent>

--- a/src/components/ui/carousel-home.tsx
+++ b/src/components/ui/carousel-home.tsx
@@ -54,25 +54,23 @@ export function CarouselHome() {
             key={index}
             className="relative flex h-[calc(100vh-3.5rem)] w-full items-center justify-center overflow-hidden pl-0"
           >
-            <div className="absolute inset-0 bg-neutral-900">
-              {index === 0 ? (
-                <Image
-                  src={imgUrl(item.image)}
-                  alt={item.title}
-                  fill
-                  priority
-                  className="object-contain"
-                />
-              ) : (
-                <Image
-                  src={imgUrl(item.image)}
-                  alt={item.title}
-                  fill
-                  loading="lazy"
-                  className="object-contain"
-                />
-              )}
-            </div>
+            {index === 0 ? (
+              <Image
+                src={imgUrl(item.image)}
+                alt={item.title}
+                fill
+                priority
+                className="object-cover"
+              />
+            ) : (
+              <Image
+                src={imgUrl(item.image)}
+                alt={item.title}
+                fill
+                loading="lazy"
+                className="object-cover"
+              />
+            )}
             <Card className="relative w-10/12 bg-white/90 shadow-lg backdrop-blur-sm md:w-xl">
               <CardHeader className="flex flex-col items-center justify-center">
                 <Badge className={`${item.chipColor} mx-auto text-black`}>

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -138,7 +138,7 @@ function CarouselContent({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       ref={carouselRef}
-      className="overflow-hidden"
+      className="w-full overflow-hidden"
       data-slot="carousel-content"
     >
       <div

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -278,21 +278,25 @@ export function MediaCarousel({ items, className }: MediaCarouselProps) {
           {items.map((item, index) => (
             <div key={index} className="relative min-w-0 flex-[0_0_100%]">
               {item.type === 'image' ? (
-                <img
-                  src={item.url}
-                  alt={item.alt}
-                  className="h-[500px] w-full object-cover"
-                />
+                <div className="flex h-[500px] w-full items-center justify-center bg-neutral-900">
+                  <img
+                    src={item.url}
+                    alt={item.alt}
+                    className="max-h-[500px] w-full object-contain"
+                  />
+                </div>
               ) : (
-                <video
-                  src={item.url}
-                  poster={item.thumbnail}
-                  controls
-                  className="h-[500px] w-full object-cover"
-                >
-                  <source src={item.url} type="video/mp4" />
-                  Tu navegador no soporta el elemento de video.
-                </video>
+                <div className="flex h-[500px] w-full items-center justify-center bg-neutral-900">
+                  <video
+                    src={item.url}
+                    poster={item.thumbnail}
+                    controls
+                    className="max-h-[500px] w-full object-contain"
+                  >
+                    <source src={item.url} type="video/mp4" />
+                    Tu navegador no soporta el elemento de video.
+                  </video>
+                </div>
               )}
             </div>
           ))}

--- a/src/components/ui/tour-media-carousel.tsx
+++ b/src/components/ui/tour-media-carousel.tsx
@@ -65,27 +65,31 @@ export function TourMediaCarousel({
               className="relative min-w-0 flex-[0_0_100%] overflow-hidden"
             >
               {item.type === 'image' ? (
-                <Image
-                  src={imgUrl(item.url, IMG_WIDTH_DETAIL)}
-                  alt={item.alt}
-                  width={500}
-                  height={500}
-                  priority={index === 0}
-                  sizes="(max-width: 768px) 100vw, 640px"
-                  className="h-[400px] w-full object-cover"
-                />
+                <div className="flex h-[400px] w-full items-center justify-center bg-neutral-900">
+                  <Image
+                    src={imgUrl(item.url, IMG_WIDTH_DETAIL)}
+                    alt={item.alt}
+                    width={800}
+                    height={800}
+                    priority={index === 0}
+                    sizes="(max-width: 768px) 100vw, 640px"
+                    className="max-h-[400px] w-full object-contain"
+                  />
+                </div>
               ) : (
-                <video
-                  src={item.url}
-                  poster={item.thumbnail ?? videoPoster(item.url)}
-                  preload={index === selectedIndex ? 'metadata' : 'none'}
-                  controls
-                  playsInline
-                  className="h-[400px] w-full object-cover"
-                >
-                  <source src={item.url} type="video/mp4" />
-                  Tu navegador no soporta el elemento de video.
-                </video>
+                <div className="flex h-[400px] w-full items-center justify-center bg-neutral-900">
+                  <video
+                    src={item.url}
+                    poster={item.thumbnail ?? videoPoster(item.url)}
+                    preload={index === selectedIndex ? 'metadata' : 'none'}
+                    controls
+                    playsInline
+                    className="max-h-[400px] w-full object-contain"
+                  >
+                    <source src={item.url} type="video/mp4" />
+                    Tu navegador no soporta el elemento de video.
+                  </video>
+                </div>
               )}
             </div>
           ))}

--- a/src/lib/__tests__/og.test.ts
+++ b/src/lib/__tests__/og.test.ts
@@ -1,0 +1,93 @@
+import { DEFAULT_OG_IMAGE, ogImageUrl, socialMetadata } from '@/lib/og'
+
+describe('ogImageUrl', () => {
+  it('returns the default logo OG when no source is given', () => {
+    expect(ogImageUrl()).toBe(DEFAULT_OG_IMAGE)
+    expect(ogImageUrl(undefined)).toBe(DEFAULT_OG_IMAGE)
+  })
+
+  it('returns the default logo OG for non-Cloudinary URLs', () => {
+    expect(ogImageUrl('https://example.com/photo.jpg')).toBe(DEFAULT_OG_IMAGE)
+  })
+
+  it('returns the default logo OG for Cloudinary URLs without a versioned public id', () => {
+    expect(
+      ogImageUrl(
+        'https://res.cloudinary.com/lesteban/image/upload/sample.jpg'
+      )
+    ).toBe(DEFAULT_OG_IMAGE)
+  })
+
+  it('builds a 1200x630 fill OG from a plain Cloudinary image', () => {
+    const src =
+      'https://res.cloudinary.com/lesteban/image/upload/v1/roadmapcol/guatape/photo.jpg'
+    const result = ogImageUrl(src)
+    expect(result).toContain('/image/upload/')
+    expect(result).toContain('w_1200')
+    expect(result).toContain('h_630')
+    expect(result).toContain('c_fill')
+    expect(result).toContain('g_auto')
+    expect(result).toContain('f_jpg')
+    expect(result).toContain('l_roadmap:road_map_sin_fondo_atjeji')
+    expect(result).toContain('v1/roadmapcol/guatape/photo.jpg')
+  })
+
+  it('strips existing transforms before applying OG transforms', () => {
+    const src =
+      'https://res.cloudinary.com/lesteban/image/upload/f_auto,q_auto,w_1600,c_limit/v1/path/photo.jpg'
+    const result = ogImageUrl(src)
+    expect(result).not.toContain('w_1600')
+    expect(result).toContain('w_1200,h_630,c_fill')
+    expect(result).toContain('v1/path/photo.jpg')
+  })
+
+  it('converts a video URL into a first-frame jpg OG', () => {
+    const src =
+      'https://res.cloudinary.com/lesteban/video/upload/v1/path/clip.mov'
+    const result = ogImageUrl(src)
+    expect(result).toContain('/image/upload/')
+    expect(result).toContain('so_0')
+    expect(result).toContain('clip.jpg')
+    expect(result).not.toContain('.mov')
+  })
+})
+
+describe('socialMetadata', () => {
+  it('returns openGraph and twitter with summary_large_image', () => {
+    const meta = socialMetadata({
+      description: 'A trip',
+      imageUrl:
+        'https://res.cloudinary.com/lesteban/image/upload/v1/tours/a.jpg',
+      title: 'Guatapé',
+      url: 'https://roadmapcol.com/tours/guatape',
+    })
+
+    expect(meta.openGraph?.title).toBe('Guatapé')
+    expect(meta.openGraph?.description).toBe('A trip')
+    expect(meta.openGraph?.url).toBe('https://roadmapcol.com/tours/guatape')
+    expect(meta.openGraph?.images).toEqual([
+      expect.objectContaining({
+        alt: 'Guatapé',
+        height: 630,
+        width: 1200,
+      }),
+    ])
+    expect(meta.twitter).toMatchObject({
+      card: 'summary_large_image',
+      title: 'Guatapé',
+    })
+    expect(meta.twitter).toMatchObject({
+      images: expect.any(Array),
+    })
+  })
+
+  it('uses default OG when imageUrl is omitted', () => {
+    const meta = socialMetadata({
+      description: 'Site',
+      title: 'Road Map Col',
+    })
+    expect(meta.openGraph?.images).toEqual([
+      expect.objectContaining({ url: DEFAULT_OG_IMAGE }),
+    ])
+  })
+})

--- a/src/lib/data.tsx
+++ b/src/lib/data.tsx
@@ -33,7 +33,7 @@ export const LANDING_LINKS = [
     description:
       'Discover the magic of Colombia with our unique and personalized experiences.',
     image:
-      'https://res.cloudinary.com/lesteban/image/upload/w_1920,q_auto,f_auto/v1748743344/roadmap/colombian-landscape_obm8nb.avif',
+      'https://res.cloudinary.com/lesteban/image/upload/w_1920,h_1080,c_fill,g_auto,q_auto,f_auto/v1748743344/roadmap/colombian-landscape_obm8nb.avif',
     href: '/tours',
     button: 'Learn more',
   },
@@ -46,7 +46,7 @@ export const LANDING_LINKS = [
     description:
       'Discover the best discounts for groups in Colombia. Special offer for groups of 10 or more people.',
     image:
-      'https://res.cloudinary.com/lesteban/image/upload/w_1920,q_auto,f_auto/v1748229430/roadmap/tourism_nsahmt.avif',
+      'https://res.cloudinary.com/lesteban/image/upload/w_1920,h_1080,c_fill,g_auto,q_auto,f_auto/v1748229430/roadmap/tourism_nsahmt.avif',
     href: '/tours',
     button: 'Learn more',
   },
@@ -59,7 +59,7 @@ export const LANDING_LINKS = [
     description:
       'Discover the magic of the mountain of Antioquia, a region full of mountains and adventure. Enjoy the nature and the Colombian culture.',
     image:
-      'https://res.cloudinary.com/lesteban/image/upload/w_1920,q_auto,f_auto/v1771547745/roadmapcol/saltodelbuey/canopy__owsi02.jpg',
+      'https://res.cloudinary.com/lesteban/image/upload/w_1920,h_1080,c_fill,g_auto,q_auto,f_auto/v1771547745/roadmapcol/saltodelbuey/canopy__owsi02.jpg',
     href: '/tours/salto-del-buey',
     button: 'See tour',
   },
@@ -75,7 +75,7 @@ export const LANDING_LINKS = [
       'such as the Peñol stone, the Guatape dam and the replica of the old ' +
       'Peñol, this place should be a must on your visit to Medellin.',
     image:
-      'https://res.cloudinary.com/lesteban/image/upload/w_1920,q_auto,f_auto/v1749941780/roadmapcol/guatape/guatape_yv0q5f.jpg',
+      'https://res.cloudinary.com/lesteban/image/upload/w_1920,h_1080,c_fill,g_auto,q_auto,f_auto/v1749941780/roadmapcol/guatape/guatape_yv0q5f.jpg',
     href: '/tours/guatape',
     button: 'See tour',
   },
@@ -88,7 +88,7 @@ export const LANDING_LINKS = [
     description:
       'Get to know the most representative places of the city of medellin, learn about its culture, gastronomy and history in a tour designed for you to live the city like a local.',
     image:
-      'https://res.cloudinary.com/lesteban/image/upload/w_1920,q_auto,f_auto/v1771548806/roadmapcol/comuna13/comuna13_vbwhk6.jpg',
+      'https://res.cloudinary.com/lesteban/image/upload/w_1920,h_1080,c_fill,g_auto,q_auto,f_auto/v1771548806/roadmapcol/comuna13/comuna13_vbwhk6.jpg',
     href: '/tours/comuna13',
     button: 'See tour',
   },
@@ -101,7 +101,7 @@ export const LANDING_LINKS = [
     description:
       'Soar above the mountains and take in stunning views of Medellín from the sky — an unforgettable experience for thrill-seekers.',
     image:
-      'https://res.cloudinary.com/lesteban/image/upload/w_1920,q_auto,f_auto/v1771548688/roadmapcol/parapente/parapente_zo57qx.jpg',
+      'https://res.cloudinary.com/lesteban/image/upload/w_1920,h_1080,c_fill,g_auto,q_auto,f_auto/v1771548688/roadmapcol/parapente/parapente_zo57qx.jpg',
     href: '/tours/paragliding',
     button: 'See tour',
   },
@@ -114,7 +114,7 @@ export const LANDING_LINKS = [
     description:
       'Escape the city and explore nearby traditional towns where local culture and customs are still alive. "Puebliar" is a favorite local activity — a way to reconnect with roots and experience authentic Colombian life.',
     image:
-      'https://res.cloudinary.com/lesteban/image/upload/w_1920,q_auto,f_auto/v1749944605/roadmapcol/oriente/oriente-1_jbhthn.jpg',
+      'https://res.cloudinary.com/lesteban/image/upload/w_1920,h_1080,c_fill,g_auto,q_auto,f_auto/v1749944605/roadmapcol/oriente/oriente-1_jbhthn.jpg',
     href: '/tours/orient-tour',
     button: 'See tour',
   },
@@ -127,7 +127,7 @@ export const LANDING_LINKS = [
     description:
       'Jardín is a heritage town in Antioquia, known for its colorful architecture, rich culture, and ecological diversity. It’s a favorite destination for both locals and tourists.',
     image:
-      'https://res.cloudinary.com/lesteban/image/upload/w_1920,q_auto,f_auto/v1771549017/roadmapcol/jardin/jardin_a8u1ox.jpg',
+      'https://res.cloudinary.com/lesteban/image/upload/w_1920,h_1080,c_fill,g_auto,q_auto,f_auto/v1771549017/roadmapcol/jardin/jardin_a8u1ox.jpg',
     href: '/tours/jardin',
     button: 'See tour',
   },

--- a/src/lib/og.ts
+++ b/src/lib/og.ts
@@ -1,0 +1,82 @@
+import type { Metadata } from 'next'
+
+export const OG_WIDTH = 1200
+export const OG_HEIGHT = 630
+
+const CLOUD_BASE = 'https://res.cloudinary.com/lesteban'
+const LOGO_PUBLIC_ID = 'v1748229585/roadmap/road_map_sin_fondo_atjeji.png'
+const LOGO_OVERLAY = 'roadmap:road_map_sin_fondo_atjeji'
+
+/** Default share image: logo centered on white 1200×630 canvas. */
+export const DEFAULT_OG_IMAGE = `${CLOUD_BASE}/image/upload/w_${OG_WIDTH},h_${OG_HEIGHT},c_pad,b_rgb:ffffff,f_jpg,q_auto/${LOGO_PUBLIC_ID}`
+
+/**
+ * Build a 1200×630 social preview from a Cloudinary image (or video frame).
+ * Falls back to the branded logo OG when the source is missing/non-Cloudinary.
+ */
+export function ogImageUrl(sourceUrl?: string): string {
+  if (!sourceUrl?.includes('res.cloudinary.com')) return DEFAULT_OG_IMAGE
+
+  const match = sourceUrl.match(
+    /^(https:\/\/res\.cloudinary\.com\/[^/]+)\/(image|video)\/upload\/(?:.*\/)?(v\d+\/.+)$/
+  )
+  if (!match) return DEFAULT_OG_IMAGE
+
+  const [, host, resourceType, publicIdWithVersion] = match
+  const isVideo = resourceType === 'video'
+  // so_0 grabs first frame; force jpg for reliable social crawlers
+  const transforms = [
+    isVideo ? 'so_0' : null,
+    `w_${OG_WIDTH}`,
+    `h_${OG_HEIGHT}`,
+    'c_fill',
+    'g_auto',
+    'f_jpg',
+    'q_auto',
+    // brand mark bottom-right
+    `l_${LOGO_OVERLAY},w_100,o_90,g_south_east,x_32,y_32`,
+  ]
+    .filter(Boolean)
+    .join(',')
+
+  const id = isVideo
+    ? publicIdWithVersion.replace(/\.(mov|mp4|webm)$/i, '.jpg')
+    : publicIdWithVersion
+
+  return `${host}/image/upload/${transforms}/${id}`
+}
+
+/** Open Graph + Twitter card metadata for any page. */
+export function socialMetadata(opts: {
+  alt?: string
+  description: string
+  imageUrl?: string
+  title: string
+  url?: string
+}): Pick<Metadata, 'openGraph' | 'twitter'> {
+  const image = ogImageUrl(opts.imageUrl)
+  const alt = opts.alt ?? opts.title
+
+  return {
+    openGraph: {
+      description: opts.description,
+      images: [
+        {
+          alt,
+          height: OG_HEIGHT,
+          url: image,
+          width: OG_WIDTH,
+        },
+      ],
+      title: opts.title,
+      type: 'website',
+      ...(opts.url ? { url: opts.url } : {}),
+    },
+    twitter: {
+      card: 'summary_large_image',
+      description: opts.description,
+      images: [image],
+      title: opts.title,
+    },
+  }
+}


### PR DESCRIPTION
## What and why
Vertical images/videos in carousels were cropped by `object-cover`, so only a slice was visible. Social shares also lacked proper 1200×630 previews per tour (and a consistent logo fallback elsewhere).

## Changes
- Use `object-contain` + dark letterbox on tour media carousel, home carousel, and MediaCarousel
- Add `src/lib/og.ts` helpers: `ogImageUrl`, `socialMetadata`, `DEFAULT_OG_IMAGE`
- Tour/blog detail OG: 1200×630 `c_fill` from tour/cover image + logo watermark
- Default OG (home, tours index, blog index, personalize, layout): logo on white 1200×630
- Wire Open Graph + Twitter `summary_large_image` on all main routes
- Unit tests for OG helpers and carousel contain behavior

## Type of change
- [x] New feature (non-breaking, adds functionality)
- [x] Bug fix (non-breaking, fixes an issue)

## Test plan
- [ ] Open a tour with vertical gallery images/videos — full media visible (no crop zoom)
- [ ] Home carousel — vertical slides show fully with dark bars if needed
- [ ] View page source on `/tours/guatape` — `og:image` is 1200×630 Cloudinary URL with logo overlay
- [ ] View page source on `/` or `/tours` — `og:image` is logo on white canvas
- [ ] Optional: paste a tour URL into https://www.opengraph.xyz/ or Twitter card validator
- [x] Run `bun test` / coverage — 100%
- [x] Run `bun run type-check` — no type errors

## Notes for reviewer
OG images are generated on the fly via Cloudinary transforms (no new uploads). Video sources use first frame (`so_0`) as jpg.