### PR TITLE
fix: optimize tour video delivery via Cloudinary transforms (#38)

### DIFF
--- a/src/lib/__tests__/cloudinary.test.ts
+++ b/src/lib/__tests__/cloudinary.test.ts
@@ -44,21 +44,21 @@ describe('videoPoster', () => {
   it('generates a jpg poster from an mp4 URL', () => {
     const url = 'https://res.cloudinary.com/demo/video/upload/sample.mp4'
     expect(videoPoster(url)).toBe(
-      'https://res.cloudinary.com/demo/video/upload/so_0/sample.jpg'
+      'https://res.cloudinary.com/demo/video/upload/so_0,w_1280,c_limit,q_auto,f_auto/sample.jpg'
     )
   })
 
   it('generates a jpg poster from a mov URL', () => {
     const url = 'https://res.cloudinary.com/demo/video/upload/sample.mov'
     expect(videoPoster(url)).toBe(
-      'https://res.cloudinary.com/demo/video/upload/so_0/sample.jpg'
+      'https://res.cloudinary.com/demo/video/upload/so_0,w_1280,c_limit,q_auto,f_auto/sample.jpg'
     )
   })
 
   it('generates a jpg poster from a webm URL', () => {
     const url = 'https://res.cloudinary.com/demo/video/upload/sample.webm'
     expect(videoPoster(url)).toBe(
-      'https://res.cloudinary.com/demo/video/upload/so_0/sample.jpg'
+      'https://res.cloudinary.com/demo/video/upload/so_0,w_1280,c_limit,q_auto,f_auto/sample.jpg'
     )
   })
 })

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -30,7 +30,10 @@ export function imgUrl(url: string, width: number = IMG_WIDTH_DETAIL): string {
 
 export function videoPoster(url: string): string {
   return url
-    .replace('/video/upload/', '/video/upload/so_0/')
+    .replace(
+      '/video/upload/',
+      '/video/upload/so_0,w_1280,c_limit,q_auto,f_auto/'
+    )
     .replace(/\.(mov|mp4|webm)$/i, '.jpg')
 }
 

--- a/src/lib/data.tsx
+++ b/src/lib/data.tsx
@@ -139,7 +139,7 @@ export const TOURS = [
     images: [
       {
         type: 'video' as const,
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1749350202/roadmapcol/saltodelbuey/IMG_4317_xbgjie.mov',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1749350202/roadmapcol/saltodelbuey/IMG_4317_xbgjie.mov',
         alt: 'Vista panorámica del Salto del Buey',
       },
       {
@@ -149,7 +149,7 @@ export const TOURS = [
       },
       {
         type: 'video' as const,
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1749350824/roadmapcol/saltodelbuey/DJI_0270_2_k5phmc.mp4',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1749350824/roadmapcol/saltodelbuey/DJI_0270_2_k5phmc.mp4',
         alt: 'Vista panorámica del Salto del Buey',
       },
 
@@ -170,22 +170,22 @@ export const TOURS = [
       },
       {
         type: 'video' as const,
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1749350239/roadmapcol/saltodelbuey/copy_CF5DE597-5748-4D6D-8025-892A124D1FB6_o7sxon.mov',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1749350239/roadmapcol/saltodelbuey/copy_CF5DE597-5748-4D6D-8025-892A124D1FB6_o7sxon.mov',
         alt: 'Vista panorámica del Salto del Buey',
       },
       {
         type: 'video' as const,
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1749350206/roadmapcol/saltodelbuey/IMG_3632_qogszv.mov',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1749350206/roadmapcol/saltodelbuey/IMG_3632_qogszv.mov',
         alt: 'Vista panorámica del Salto del Buey',
       },
       {
         type: 'video' as const,
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1749350206/roadmapcol/saltodelbuey/IMG_4310_lx7ofw.mov',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1749350206/roadmapcol/saltodelbuey/IMG_4310_lx7ofw.mov',
         alt: 'Canopy',
       },
       {
         type: 'video' as const,
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1749350202/roadmapcol/saltodelbuey/IMG_4317_xbgjie.mov',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1749350202/roadmapcol/saltodelbuey/IMG_4317_xbgjie.mov',
         alt: 'Salto del buey',
       },
     ],
@@ -403,7 +403,7 @@ export const TOURS = [
     images: [
       {
         type: 'video',
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1749943355/roadmapcol/parapente/parapente-5_qpyri0.mp4',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1749943355/roadmapcol/parapente/parapente-5_qpyri0.mp4',
         alt: 'parapente',
       },
       {
@@ -413,7 +413,7 @@ export const TOURS = [
       },
       {
         type: 'video',
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1749943368/roadmapcol/parapente/parapente-4_lkxlwx.mov',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1749943368/roadmapcol/parapente/parapente-4_lkxlwx.mov',
         alt: 'parapente',
       },
       {
@@ -423,7 +423,7 @@ export const TOURS = [
       },
       {
         type: 'video',
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1749943359/roadmapcol/parapente/parapente-3_rq6vsk.mov',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1749943359/roadmapcol/parapente/parapente-3_rq6vsk.mov',
         alt: 'parapente',
       },
     ],
@@ -456,7 +456,7 @@ export const TOURS = [
     images: [
       {
         type: 'video',
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1749944620/roadmapcol/oriente/oriente-2_abvz83.mov',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1749944620/roadmapcol/oriente/oriente-2_abvz83.mov',
         alt: 'parapente',
       },
       {
@@ -692,12 +692,12 @@ export const TOURS = [
       },
       {
         type: 'video' as const,
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1771549976/roadmapcol/maviCartagena/c6b1b508-aae3-4726-9f98-14870563425f_ar1pey.mov',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1771549976/roadmapcol/maviCartagena/c6b1b508-aae3-4726-9f98-14870563425f_ar1pey.mov',
         alt: 'MAVI Cartagena',
       },
       {
         type: 'video' as const,
-        url: 'https://res.cloudinary.com/lesteban/video/upload/v1771549917/roadmapcol/maviCartagena/video_presentacion_f1lmbk.mov',
+        url: 'https://res.cloudinary.com/lesteban/video/upload/f_auto,q_auto,w_1280,c_limit/v1771549917/roadmapcol/maviCartagena/video_presentacion_f1lmbk.mov',
         alt: 'MAVI Cartagena - Presentation',
       },
     ],


### PR DESCRIPTION
## What and why
Tour gallery videos in `data.tsx` were served straight from Cloudinary with
no transformations — several raw `.mov` originals (13.7–75.6 MB) were being
downloaded on page load/play, and `.mov` often doesn't even play in
Chrome/Firefox on non-Apple platforms.

## Changes
- Add `f_auto,q_auto,w_1280,c_limit` to all 12 video URLs in `data.tsx`
- Cap `videoPoster()` output at `so_0,w_1280,c_limit,q_auto,f_auto` so
  poster thumbnails aren't extracted from the full-resolution source
- Update `cloudinary.test.ts` to match the new poster output

## Type of change
- [x] Bug fix (non-breaking, fixes an issue)

## Test plan
- [x] `bun run lint` — clean (2 pre-existing warnings unrelated to this branch)
- [x] `bun run type-check` — no errors
- [x] `bunx vitest run --coverage` — 212/212 tests passing, 100% coverage
- [ ] Manually verify a tour gallery video plays in Chrome and Firefox after deploy (transcoding happens on Cloudinary's side, can't be verified from `bun dev` alone)
- [ ] Re-run Lighthouse on a tour page after deploy to confirm "Avoid enormous network payloads" no longer flags it

## Notes for reviewer
- `f_auto` lets Cloudinary transcode `.mov` originals to a browser-appropriate format (mp4/webm) on delivery, so no source re-encoding/re-upload was needed.
- The two checklist items above depend on Cloudinary's CDN actually transforming the assets, which only happens for real (deployed) requests, not the local dev server.

---
Closes #38