### PR TITLE
fix: add Content-Security-Policy header (#31)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,19 @@
 import type { NextConfig } from 'next'
 
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://va.vercel-scripts.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: https://res.cloudinary.com https://www.googletagmanager.com https://www.google-analytics.com",
+  "media-src 'self' https://res.cloudinary.com",
+  "connect-src 'self' https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com",
+  'frame-src https://www.googletagmanager.com',
+  "font-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+].join('; ')
+
 const securityHeaders = [
   { key: 'X-Frame-Options', value: 'DENY' },
   { key: 'X-Content-Type-Options', value: 'nosniff' },
@@ -15,11 +29,15 @@ const securityHeaders = [
     key: 'Strict-Transport-Security',
     value: 'max-age=63072000; includeSubDomains; preload',
   },
+  {
+    key: 'Content-Security-Policy',
+    value: contentSecurityPolicy,
+  },
 ]
 
 const nextConfig: NextConfig = {
   async headers() {
-    return [{ headers: securityHeaders, source: '/(.*)', }]
+    return [{ headers: securityHeaders, source: '/(.*)' }]
   },
   images: {
     remotePatterns: [

--- a/src/components/ui/__tests__/header.test.tsx
+++ b/src/components/ui/__tests__/header.test.tsx
@@ -74,4 +74,33 @@ describe('Header', () => {
       screen.queryByRole('button', { name: 'Close menu' })
     ).not.toBeInTheDocument()
   })
+
+  it('scrolls to top instead of navigating when the Home link is clicked on the home page', () => {
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+    render(<Header />)
+
+    fireEvent.click(screen.getAllByText('Home')[0])
+
+    expect(scrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 0 })
+  })
+
+  it('scrolls to top when the logo is clicked on the home page', () => {
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+    const { container } = render(<Header />)
+    const logoLink = container.querySelector('a[href="/"]')!
+
+    fireEvent.click(logoLink)
+
+    expect(scrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 0 })
+  })
+
+  it('does not scroll and navigates normally when Home is clicked from another page', () => {
+    vi.mocked(usePathname).mockReturnValue('/tours')
+    const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+    render(<Header />)
+
+    fireEvent.click(screen.getAllByText('Home')[0])
+
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
 })

--- a/src/components/ui/__tests__/tour-media-carousel.test.tsx
+++ b/src/components/ui/__tests__/tour-media-carousel.test.tsx
@@ -150,6 +150,32 @@ describe('TourMediaCarousel', () => {
     expect(window.HTMLMediaElement.prototype.pause).toHaveBeenCalled()
   })
 
+  it('reorders items so an image always leads, even if the data has a video first', () => {
+    render(
+      <TourMediaCarousel
+        items={[
+          {
+            alt: 'Leading video',
+            type: 'video' as const,
+            url: 'https://example.com/video.mp4',
+          },
+          {
+            alt: 'Trailing image',
+            type: 'image' as const,
+            url: 'https://res.cloudinary.com/demo/image/upload/a.jpg',
+          },
+        ]}
+      />
+    )
+
+    const image = screen.getByAltText('Trailing image')
+    const video = document.querySelector('video')
+    expect(video).toBeInTheDocument()
+    expect(
+      image.compareDocumentPosition(video!) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
   it('renders without error when embla api is undefined', () => {
     vi.mocked(useEmblaCarousel).mockReturnValue([mockRef, undefined])
     render(<TourMediaCarousel items={imageItems} />)

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -7,6 +7,7 @@ import { MenuIcon, XIcon } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import type { MouseEvent } from 'react'
 import { useEffect, useState } from 'react'
 
 const SCROLL_THRESHOLD = 16
@@ -17,6 +18,16 @@ export default function Header() {
   const [isScrolled, setIsScrolled] = useState(false)
   const isHome = pathname === '/'
   const isTransparent = isHome && !isScrolled && !isMenuOpen
+
+  const handleHomeClick = (
+    event: MouseEvent<HTMLAnchorElement>,
+    href: string
+  ) => {
+    if (href === '/' && isHome) {
+      event.preventDefault()
+      window.scrollTo({ behavior: 'smooth', top: 0 })
+    }
+  }
 
   useEffect(() => {
     if (!isHome) {
@@ -42,7 +53,7 @@ export default function Header() {
       )}
     >
       <nav className="container flex h-14 items-center justify-between px-4 md:px-8">
-        <Link href="/">
+        <Link href="/" onClick={(e) => handleHomeClick(e, '/')}>
           <Image src={images.logo} alt="logo" width={60} height={60} />
         </Link>
         <div className="hidden gap-6 md:flex">
@@ -50,6 +61,7 @@ export default function Header() {
             <Link
               key={link.href}
               href={link.href}
+              onClick={(e) => handleHomeClick(e, link.href)}
               className={cn(
                 'text-sm font-medium transition-all duration-300 hover:underline',
                 isTransparent
@@ -83,7 +95,10 @@ export default function Header() {
               <Link
                 key={link.href}
                 href={link.href}
-                onClick={() => setIsMenuOpen(false)}
+                onClick={(e) => {
+                  handleHomeClick(e, link.href)
+                  setIsMenuOpen(false)
+                }}
                 className={cn(
                   'hover:text-primary hover:bg-accent flex min-h-20 flex-1 items-center justify-center gap-3 px-8 text-xl font-medium transition-all duration-300',
                   pathname === link.href &&

--- a/src/components/ui/tour-media-carousel.tsx
+++ b/src/components/ui/tour-media-carousel.tsx
@@ -21,6 +21,13 @@ export function TourMediaCarousel({
   items,
   className,
 }: TourMediaCarouselProps) {
+  const orderedItems = React.useMemo(
+    () =>
+      [...items].sort(
+        (a, b) => Number(a.type === 'video') - Number(b.type === 'video')
+      ),
+    [items]
+  )
   const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true })
   const [selectedIndex, setSelectedIndex] = React.useState(0)
   const [scrollSnaps, setScrollSnaps] = React.useState<number[]>([])
@@ -59,7 +66,7 @@ export function TourMediaCarousel({
     <div className={cn('relative w-full', className)}>
       <div className="overflow-hidden rounded-t-lg" ref={emblaRef}>
         <div className="flex">
-          {items.map((item, index) => (
+          {orderedItems.map((item, index) => (
             <div
               key={index}
               className="relative min-w-0 flex-[0_0_100%] overflow-hidden"


### PR DESCRIPTION
## What and why
`next.config.ts` set several security headers but no `Content-Security-Policy`,
leaving no defense-in-depth against injected/malicious scripts (e.g. via a
compromised third-party tag or a future XSS bug in a `dangerouslySetInnerHTML`
usage such as `json-ld.tsx` or `gtm.tsx`).

Two small, related fixes are bundled in per request:
- The header's Home link/logo didn't scroll to top when already on `/`
  (Next.js treats it as a same-URL no-op navigation)
- Tour detail galleries could show a multi-MB video as the very first slide,
  delaying the perceived load — first slide is now always an image when one exists

## Changes
- Add a `Content-Security-Policy` header to `securityHeaders` in `next.config.ts`, restricting `default-src 'self'` and explicitly allowing GTM/GA, Vercel Analytics, and Cloudinary (`script-src`, `style-src`, `img-src`, `media-src`, `connect-src`, `frame-src`)
- `Header`: clicking the logo or the Home link while already on `/` now calls `window.scrollTo({ top: 0, behavior: 'smooth' })` instead of no-op navigating
- `TourMediaCarousel`: reorder `items` (stable sort) so images always come before videos, guaranteeing the first slide is an image
- Add/adjust tests for all of the above

## Type of change
- [x] Bug fix (non-breaking, fixes an issue)

## Test plan
- [x] `bun run lint` — clean (2 pre-existing warnings unrelated to this branch)
- [x] `bun run type-check` — no errors
- [x] `bunx vitest run --coverage` — 216/216 tests passing, 100% coverage
- [x] `bun run build && bun run start` — confirmed `Content-Security-Policy` header via `curl -I`
- [x] Headless Playwright pass over `/`, `/tours/salto-del-buey`, `/personalize` on the production build — **0 CSP console violations** (verified `media-src` was needed for Cloudinary video playback, added it)
- [x] Verified via Playwright: first gallery slide on a tour with a leading video in the data is now an image; clicking Home on `/` scrolls from `scrollY=800` back to `0`

## Notes for reviewer
- `script-src`/`style-src` include `'unsafe-inline'` — GTM's bootstrap snippet is an inline `<script>` and several components (marquee animation duration, Radix positioning) set inline `style`. A stricter nonce-based CSP would need a middleware layer, which felt out of scope for this issue.
- The `/_vercel/insights/script.js` 404 seen locally is expected (that endpoint only exists on Vercel's platform) and isn't a CSP violation.
- Manual Lighthouse re-check on a deployed preview is still worth doing but couldn't be done from this environment.

---
Closes #31