### PR TITLE
fix: remove unused Geist Mono font (#43)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,6 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-inter);
-  --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,7 @@ import { DEFAULT_OG_IMAGE, OG_HEIGHT, OG_WIDTH } from '@/lib/og'
 import { organizationSchema } from '@/lib/structured-data'
 import { Analytics } from '@vercel/analytics/next'
 import type { Metadata } from 'next'
-import { Geist_Mono, Inter } from 'next/font/google'
+import { Inter } from 'next/font/google'
 import Image from 'next/image'
 import Link from 'next/link'
 
@@ -18,11 +18,6 @@ const isProduction = process.env.NODE_ENV === 'production'
 
 const inter = Inter({
   variable: '--font-inter',
-  subsets: ['latin'],
-})
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
   subsets: ['latin'],
 })
 
@@ -76,7 +71,7 @@ export default function RootLayout({
       </head>
       {isProduction && <GTM />}
       <body
-        className={` ${inter.variable} ${geistMono.variable} grid min-h-dvh w-full grid-rows-[auto_1fr_auto] antialiased`}
+        className={`${inter.variable} grid min-h-dvh w-full grid-rows-[auto_1fr_auto] antialiased`}
       >
         {isProduction && <GTMNoscript />}
         <Header />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -71,7 +71,7 @@ export default function RootLayout({
       </head>
       {isProduction && <GTM />}
       <body
-        className={`${inter.variable} grid min-h-dvh w-full grid-rows-[auto_1fr_auto] antialiased`}
+        className={`${inter.variable} grid min-h-dvh w-full grid-rows-[auto_1fr_auto] font-sans antialiased`}
       >
         {isProduction && <GTMNoscript />}
         <Header />

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -37,10 +37,6 @@ vi.mock('next/font/local', () => ({
 }))
 
 vi.mock('next/font/google', () => ({
-  Geist_Mono: vi.fn(() => ({
-    className: 'mocked-geist-mono',
-    variable: '--font-geist-mono',
-  })),
   Inter: vi.fn(() => ({
     className: 'mocked-inter',
     variable: '--font-inter',


### PR DESCRIPTION
## What and why
`layout.tsx` loaded two Google font families (`Geist_Mono` alongside `Inter`),
but `font-mono` was never used anywhere in `src/` — only the CSS variable
declaration in `globals.css` referenced it. Every page paid for the Geist
Mono stylesheet + woff2 download for zero visual benefit.

While verifying the fix, also found and fixed: `--font-sans: var(--font-inter)`
was declared in `globals.css` but never actually applied anywhere (no
`font-sans` utility class or `font-family` rule referenced it), so the site
was silently rendering with the browser's default sans-serif stack instead
of Inter, even though Inter was being correctly fetched.

## Changes
- Remove `Geist_Mono` import/const and its `className` variable from `layout.tsx`
- Remove `--font-mono: var(--font-geist-mono);` from the `@theme inline` block in `globals.css`
- Remove the now-unused `Geist_Mono` mock from `test/setup.ts`
- Add `font-sans` to the `<body>` className so `--font-sans` (Inter) is actually applied

## Type of change
- [x] Performance improvement (non-breaking)
- [x] Bug fix (non-breaking, fixes an issue)

## Test plan
- [x] `bun run lint` — clean (2 pre-existing warnings unrelated to this branch)
- [x] `bun run type-check` — no errors
- [x] `bunx vitest run --coverage` — 221/221 tests passing, 100% coverage
- [x] `bun run build && bun run start`, then a headless network check on `/`: only Inter's woff2 (+ the unrelated `oneBrush` display font used for hero titles) is fetched — no Geist Mono file
- [x] Headless check confirms `getComputedStyle(document.body).fontFamily` is now `"Inter, \"Inter Fallback\""` (previously the Tailwind Preflight default sans-serif stack)

---
Closes #43