### PR TITLE
feat: reduce unnecessary client JS on tour/personalize pages, add review schema

### DIFF
--- a/src/app/personalize/page.tsx
+++ b/src/app/personalize/page.tsx
@@ -1,3 +1,4 @@
+import { Title } from '@/components/ui/typography/typography'
 import { socialMetadata } from '@/lib/og'
 import type { Metadata } from 'next'
 
@@ -18,5 +19,14 @@ export const metadata: Metadata = {
 }
 
 export default function PersonalizePage() {
-  return <PersonalizeClient />
+  return (
+    <section className="mx-auto my-14 flex w-11/12 flex-col items-center justify-center gap-4 md:w-6/12">
+      <Title>Personalized tour</Title>
+      <p className="text-muted-foreground">
+        Don&apos;t find what you&apos;re looking for? Tell us what type of
+        experience you want and we will design a itinerary to your measure.{' '}
+      </p>
+      <PersonalizeClient />
+    </section>
+  )
 }

--- a/src/app/personalize/personalize-client.tsx
+++ b/src/app/personalize/personalize-client.tsx
@@ -5,7 +5,6 @@ import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { Title } from '@/components/ui/typography/typography'
 import { CONTACT } from '@/lib/data'
 import { cn } from '@/lib/utils'
 import {
@@ -91,12 +90,7 @@ export default function PersonalizeClient() {
   )
 
   return (
-    <section className="mx-auto my-14 flex w-11/12 flex-col items-center justify-center gap-4 md:w-6/12">
-      <Title>Personalized tour</Title>
-      <p className="text-muted-foreground">
-        Don&apos;t find what you&apos;re looking for? Tell us what type of
-        experience you want and we will design a itinerary to your measure.{' '}
-      </p>
+    <>
       <Card className="w-full p-4">
         <div className="flex flex-col gap-4">
           <h2 className="text-lg font-bold">Personal information</h2>
@@ -217,6 +211,6 @@ export default function PersonalizeClient() {
           </Link>
         </div>
       </Card>
-    </section>
+    </>
   )
 }

--- a/src/app/tours/[name]/activity-toggle-button.tsx
+++ b/src/app/tours/[name]/activity-toggle-button.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+
+import { useTourBooking } from './tour-booking-context'
+
+export function ActivityToggleButton({
+  activityTitle,
+}: {
+  activityTitle: string
+}) {
+  const { isSelected, toggleActivity } = useTourBooking()
+  const selected = isSelected(activityTitle)
+
+  return (
+    <Button
+      variant={selected ? 'outline' : 'default'}
+      onClick={() => toggleActivity(activityTitle)}
+    >
+      {selected ? 'Remove from my experience' : 'Add to my experience'}
+    </Button>
+  )
+}

--- a/src/app/tours/[name]/booking-summary.tsx
+++ b/src/app/tours/[name]/booking-summary.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader } from '@/components/ui/card'
+import { CONTACT } from '@/lib/data'
+import { images } from '@/lib/images'
+import Image from 'next/image'
+import Link from 'next/link'
+import { useMemo } from 'react'
+
+import { useTourBooking } from './tour-booking-context'
+
+interface Activity {
+  price?: number
+  title: string
+}
+
+export function BookingSummary({
+  activities,
+  basePrice,
+  tourTitle,
+}: {
+  activities: Activity[]
+  basePrice: number
+  tourTitle: string
+}) {
+  const { selectedActivities } = useTourBooking()
+
+  const getSelectedActivityPrice = (activityTitle: string) => {
+    const activity = activities.find(
+      (activity) => activity.title === activityTitle
+    )
+    return Number(activity?.price ?? 0)
+  }
+
+  const totalPrice =
+    basePrice +
+    selectedActivities.reduce(
+      (acc, title) => acc + getSelectedActivityPrice(title),
+      0
+    )
+
+  const message = useMemo(
+    () =>
+      `Hello, I would like to get more information about the tour ${tourTitle}${selectedActivities.length > 0 ? `, with the activities: ${selectedActivities.join(', ')}` : ''}. With an approximate value of ${totalPrice}`,
+    [tourTitle, selectedActivities, totalPrice]
+  )
+
+  return (
+    <Card className="mx-auto w-11/12 px-4 md:w-full">
+      <CardHeader>
+        <h2 className="text-2xl font-bold">Summary of your experience</h2>
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <p className="text-muted-foreground">Base price:</p>
+            <p className="text-lg font-bold">
+              ${Number(basePrice).toLocaleString()} / person
+            </p>
+          </div>
+          {selectedActivities.length > 0 && (
+            <>
+              <div className="border-t pt-4">
+                <p className="mb-2 font-bold">Selected activities:</p>
+                {selectedActivities.map((title) => (
+                  <div
+                    key={title}
+                    className="flex items-center justify-between"
+                  >
+                    <p className="text-muted-foreground">{title}</p>
+                    <p className="font-bold">
+                      $
+                      {Number(getSelectedActivityPrice(title)).toLocaleString()}
+                    </p>
+                  </div>
+                ))}
+              </div>
+              <div className="border-t pt-4">
+                <div className="flex items-center justify-between">
+                  <p className="text-lg font-bold">Total:</p>
+                  <p className="text-lg font-bold">
+                    ${Number(totalPrice).toLocaleString()}
+                  </p>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </CardHeader>
+      <Button
+        className="flex w-full items-center gap-2 bg-green-500 text-white hover:bg-green-600"
+        asChild
+      >
+        <Link
+          href={`https://wa.me/${CONTACT.phone}?text=${encodeURIComponent(message)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Image src={images.whatsapp} alt="whatsapp" width={20} height={20} />
+          <p>Consult by Whatsapp</p>
+        </Link>
+      </Button>
+    </Card>
+  )
+}

--- a/src/app/tours/[name]/tour-booking-context.tsx
+++ b/src/app/tours/[name]/tour-booking-context.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
+
+interface TourBookingContextValue {
+  isSelected: (activityTitle: string) => boolean
+  selectedActivities: string[]
+  toggleActivity: (activityTitle: string) => void
+}
+
+const TourBookingContext = createContext<TourBookingContextValue | null>(null)
+
+export function TourBookingProvider({ children }: { children: ReactNode }) {
+  const [selectedActivities, setSelectedActivities] = useState<string[]>([])
+
+  const toggleActivity = (activityTitle: string) => {
+    setSelectedActivities((prev) =>
+      prev.includes(activityTitle)
+        ? prev.filter((title) => title !== activityTitle)
+        : [...prev, activityTitle]
+    )
+  }
+
+  const value = useMemo(
+    () => ({
+      isSelected: (activityTitle: string) =>
+        selectedActivities.includes(activityTitle),
+      selectedActivities,
+      toggleActivity,
+    }),
+    [selectedActivities]
+  )
+
+  return (
+    <TourBookingContext.Provider value={value}>
+      {children}
+    </TourBookingContext.Provider>
+  )
+}
+
+export function useTourBooking() {
+  const context = useContext(TourBookingContext)
+  if (!context) {
+    throw new Error('useTourBooking must be used within TourBookingProvider')
+  }
+  return context
+}

--- a/src/app/tours/[name]/tour-client.tsx
+++ b/src/app/tours/[name]/tour-client.tsx
@@ -1,16 +1,14 @@
-'use client'
-
-import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { StarRating } from '@/components/ui/star-rating'
 import { TourMediaCarousel } from '@/components/ui/tour-media-carousel'
 import { IMG_WIDTH_CARD, IMG_WIDTH_DETAIL, imgUrl } from '@/lib/cloudinary'
-import { CONTACT } from '@/lib/data'
-import { images } from '@/lib/images'
 import { ArrowLeft, Check, Clock, MapPin } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useMemo, useState } from 'react'
+
+import { ActivityToggleButton } from './activity-toggle-button'
+import { BookingSummary } from './booking-summary'
+import { TourBookingProvider } from './tour-booking-context'
 
 interface Activity {
   description: string
@@ -40,206 +38,116 @@ export interface Tour {
 }
 
 export default function TourClient({ tour }: { tour: Tour }) {
-  const [selectedActivities, setSelectedActivities] = useState<string[]>([])
-
-  const getSelectedActivityPrice = (activityTitle: string) => {
-    const activity = tour.activities?.find(
-      (activity) => activity.title === activityTitle
-    )
-    return Number(activity?.price ?? 0)
-  }
-
-  const totalPrice =
-    tour.price +
-    selectedActivities.reduce(
-      (acc, title) => acc + getSelectedActivityPrice(title),
-      0
-    )
-
-  const message = useMemo(
-    () =>
-      `Hello, I would like to get more information about the tour ${tour.title}${selectedActivities.length > 0 ? `, with the activities: ${selectedActivities.join(', ')}` : ''}. With an approximate value of ${totalPrice}`,
-    [tour, selectedActivities, totalPrice]
-  )
-
-  const handleActivityToggle = (activityTitle: string) => {
-    setSelectedActivities((prev) => {
-      if (prev.includes(activityTitle)) {
-        return prev.filter((title) => title !== activityTitle)
-      }
-      return [...prev, activityTitle]
-    })
-  }
-
   return (
-    <div className="mx-auto my-14 flex flex-col items-center justify-center gap-12 md:w-6/12">
-      <Link
-        href="/tours"
-        className="text-muted-foreground hover:text-foreground flex items-center gap-2 self-start text-sm transition-colors duration-200"
-      >
-        <ArrowLeft className="h-4 w-4" />
-        Back to tours
-      </Link>
-      <Card className="mx-auto flex w-11/12 flex-col pt-0 md:w-full">
-        <CardHeader className="px-0 pt-0">
-          {tour.images ? (
-            <TourMediaCarousel items={tour.images} />
-          ) : (
-            <Image
-              src={imgUrl(tour.image, IMG_WIDTH_DETAIL)}
-              alt={tour.place}
-              width={500}
-              height={500}
-              className="aspect-[4/3] w-full rounded-t-[14px] object-cover"
-            />
-          )}
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center gap-4">
-            <div className="text-muted-foreground flex items-center gap-1">
-              <MapPin />
-              <p>{tour.place}</p>
+    <TourBookingProvider>
+      <div className="mx-auto my-14 flex flex-col items-center justify-center gap-12 md:w-6/12">
+        <Link
+          href="/tours"
+          className="text-muted-foreground hover:text-foreground flex items-center gap-2 self-start text-sm transition-colors duration-200"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to tours
+        </Link>
+        <Card className="mx-auto flex w-11/12 flex-col pt-0 md:w-full">
+          <CardHeader className="px-0 pt-0">
+            {tour.images ? (
+              <TourMediaCarousel items={tour.images} />
+            ) : (
+              <Image
+                src={imgUrl(tour.image, IMG_WIDTH_DETAIL)}
+                alt={tour.place}
+                width={500}
+                height={500}
+                className="aspect-[4/3] w-full rounded-t-[14px] object-cover"
+              />
+            )}
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <div className="flex flex-wrap items-center gap-4">
+              <div className="text-muted-foreground flex items-center gap-1">
+                <MapPin />
+                <p>{tour.place}</p>
+              </div>
+              <div className="text-muted-foreground flex items-center gap-1">
+                <Clock />
+                <p>{tour.duration}</p>
+              </div>
             </div>
-            <div className="text-muted-foreground flex items-center gap-1">
-              <Clock />
-              <p>{tour.duration}</p>
-            </div>
-          </div>
-          <h2 className="text-2xl font-bold">{tour.title}</h2>
-          {tour.rating !== undefined && <StarRating rating={tour.rating} />}
-          <p className="text-muted-foreground">{tour.description}</p>
-          <h3 className="text-xl font-bold">Highlights:</h3>
-          <ul className="grid list-inside list-disc gap-2 md:grid-cols-2">
-            {tour.highlights.map((highlight) => (
-              <li key={highlight}>{highlight}</li>
-            ))}
-          </ul>
-        </CardContent>
-      </Card>
+            <h2 className="text-2xl font-bold">{tour.title}</h2>
+            {tour.rating !== undefined && <StarRating rating={tour.rating} />}
+            <p className="text-muted-foreground">{tour.description}</p>
+            <h3 className="text-xl font-bold">Highlights:</h3>
+            <ul className="grid list-inside list-disc gap-2 md:grid-cols-2">
+              {tour.highlights.map((highlight) => (
+                <li key={highlight}>{highlight}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
 
-      {tour.activities.length > 0 && (
-        <h2 className="ml-4 self-start text-2xl font-bold">
-          Available activities:
-        </h2>
-      )}
-      <div className="flex flex-col gap-4">
-        {tour.activities.length > 0
-          ? tour.activities.map((activity) => (
-              <Card
-                key={activity.title}
-                className="mx-auto flex w-11/12 flex-col py-0 md:w-full md:flex-row"
-              >
-                <Image
-                  src={imgUrl(activity.image, IMG_WIDTH_CARD)}
-                  alt={activity.title}
-                  width={200}
-                  height={200}
-                  className="w-full rounded-t-[14px] object-cover md:w-4/12 md:rounded-l-[14px] md:rounded-r-none"
-                />
-                <div className="flex flex-col gap-2 p-4">
-                  <div className="flex w-full items-center justify-between gap-4">
-                    <h3 className="text-xl font-bold">{activity.title}</h3>
-                    <p className="text-muted-foreground">{activity.duration}</p>
-                  </div>
-                  <p className="text-muted-foreground">
-                    {activity.description}
-                  </p>
-                  {activity.includes && (
-                    <div>
-                      <p className="font-bold">Includes:</p>
-                      <ul className="grid grid-cols-2 gap-2">
-                        {activity.includes.map((include: string) => (
-                          <li key={include} className="flex items-center gap-2">
-                            <Check className="text-primary h-4 w-4" />
-                            {include}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                  <div className="flex items-center justify-between">
-                    <p className="text-secondary text-xl font-bold">
-                      ${Number(activity.price).toLocaleString()}
-                    </p>
-                    <Button
-                      variant={
-                        selectedActivities.includes(activity.title)
-                          ? 'outline'
-                          : 'default'
-                      }
-                      onClick={() => handleActivityToggle(activity.title)}
-                    >
-                      {selectedActivities.includes(activity.title)
-                        ? 'Remove from my experience'
-                        : 'Add to my experience'}
-                    </Button>
-                  </div>
-                </div>
-              </Card>
-            ))
-          : null}
-      </div>
-      <Card className="mx-auto w-11/12 px-4 md:w-full">
-        <CardHeader>
-          <h2 className="text-2xl font-bold">Summary of your experience</h2>
-          <div className="flex flex-col gap-4">
-            <div className="flex items-center justify-between">
-              <p className="text-muted-foreground">Base price:</p>
-              <p className="text-lg font-bold">
-                ${Number(tour.price).toLocaleString()} / person
-              </p>
-            </div>
-            {selectedActivities.length > 0 && (
-              <>
-                <div className="border-t pt-4">
-                  <p className="mb-2 font-bold">Selected activities:</p>
-                  {selectedActivities.map((title) => (
-                    <div
-                      key={title}
-                      className="flex items-center justify-between"
-                    >
-                      <p className="text-muted-foreground">{title}</p>
-                      <p className="font-bold">
-                        $
-                        {Number(
-                          getSelectedActivityPrice(title)
-                        ).toLocaleString()}
+        {tour.activities.length > 0 && (
+          <h2 className="ml-4 self-start text-2xl font-bold">
+            Available activities:
+          </h2>
+        )}
+        <div className="flex flex-col gap-4">
+          {tour.activities.length > 0
+            ? tour.activities.map((activity) => (
+                <Card
+                  key={activity.title}
+                  className="mx-auto flex w-11/12 flex-col py-0 md:w-full md:flex-row"
+                >
+                  <Image
+                    src={imgUrl(activity.image, IMG_WIDTH_CARD)}
+                    alt={activity.title}
+                    width={200}
+                    height={200}
+                    className="w-full rounded-t-[14px] object-cover md:w-4/12 md:rounded-l-[14px] md:rounded-r-none"
+                  />
+                  <div className="flex flex-col gap-2 p-4">
+                    <div className="flex w-full items-center justify-between gap-4">
+                      <h3 className="text-xl font-bold">{activity.title}</h3>
+                      <p className="text-muted-foreground">
+                        {activity.duration}
                       </p>
                     </div>
-                  ))}
-                </div>
-                <div className="border-t pt-4">
-                  <div className="flex items-center justify-between">
-                    <p className="text-lg font-bold">Total:</p>
-                    <p className="text-lg font-bold">
-                      ${Number(totalPrice).toLocaleString()}
+                    <p className="text-muted-foreground">
+                      {activity.description}
                     </p>
+                    {activity.includes && (
+                      <div>
+                        <p className="font-bold">Includes:</p>
+                        <ul className="grid grid-cols-2 gap-2">
+                          {activity.includes.map((include: string) => (
+                            <li
+                              key={include}
+                              className="flex items-center gap-2"
+                            >
+                              <Check className="text-primary h-4 w-4" />
+                              {include}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                    <div className="flex items-center justify-between">
+                      <p className="text-secondary text-xl font-bold">
+                        ${Number(activity.price).toLocaleString()}
+                      </p>
+                      <ActivityToggleButton activityTitle={activity.title} />
+                    </div>
                   </div>
-                </div>
-              </>
-            )}
-          </div>
-        </CardHeader>
-        <Button
-          className="flex w-full items-center gap-2 bg-green-500 text-white hover:bg-green-600"
-          asChild
-        >
-          <Link
-            href={`https://wa.me/${CONTACT.phone}?text=${encodeURIComponent(message)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              src={images.whatsapp}
-              alt="whatsapp"
-              width={20}
-              height={20}
-            />
-            <p>Consult by Whatsapp</p>
-          </Link>
-        </Button>
-      </Card>
-      <div className="flex justify-center"></div>
-    </div>
+                </Card>
+              ))
+            : null}
+        </div>
+        <BookingSummary
+          activities={tour.activities}
+          basePrice={tour.price}
+          tourTitle={tour.title}
+        />
+        <div className="flex justify-center"></div>
+      </div>
+    </TourBookingProvider>
   )
 }

--- a/src/app/tours/__tests__/tour-booking-context.test.tsx
+++ b/src/app/tours/__tests__/tour-booking-context.test.tsx
@@ -1,0 +1,46 @@
+import {
+  TourBookingProvider,
+  useTourBooking,
+} from '@/app/tours/[name]/tour-booking-context'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+function Consumer() {
+  const { isSelected, selectedActivities, toggleActivity } = useTourBooking()
+  return (
+    <div>
+      <p>selected: {selectedActivities.join(', ') || 'none'}</p>
+      <p>is-tour-selected: {isSelected('Tour') ? 'yes' : 'no'}</p>
+      <button onClick={() => toggleActivity('Tour')}>Toggle Tour</button>
+    </div>
+  )
+}
+
+describe('TourBookingProvider / useTourBooking', () => {
+  it('tracks and toggles selected activities', () => {
+    render(
+      <TourBookingProvider>
+        <Consumer />
+      </TourBookingProvider>
+    )
+
+    expect(screen.getByText('selected: none')).toBeInTheDocument()
+    expect(screen.getByText('is-tour-selected: no')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Toggle Tour'))
+    expect(screen.getByText('selected: Tour')).toBeInTheDocument()
+    expect(screen.getByText('is-tour-selected: yes')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Toggle Tour'))
+    expect(screen.getByText('selected: none')).toBeInTheDocument()
+  })
+
+  it('throws when used outside a TourBookingProvider', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => render(<Consumer />)).toThrow(
+      'useTourBooking must be used within TourBookingProvider'
+    )
+
+    consoleError.mockRestore()
+  })
+})

--- a/src/lib/__tests__/structured-data.test.ts
+++ b/src/lib/__tests__/structured-data.test.ts
@@ -1,3 +1,4 @@
+import { TESTIMONIALS } from '@/lib/data'
 import {
   blogBreadcrumbSchema,
   blogPostingSchema,
@@ -26,6 +27,28 @@ describe('structured-data', () => {
       const schema = organizationSchema()
       expect(Array.isArray(schema.sameAs)).toBe(true)
       expect(schema.sameAs.length).toBeGreaterThan(0)
+    })
+
+    it('includes an aggregateRating derived from TESTIMONIALS', () => {
+      const schema = organizationSchema()
+      expect(schema.aggregateRating['@type']).toBe('AggregateRating')
+      expect(schema.aggregateRating.reviewCount).toBe(TESTIMONIALS.length)
+      expect(schema.aggregateRating.ratingValue).toBeGreaterThan(0)
+      expect(schema.aggregateRating.ratingValue).toBeLessThanOrEqual(5)
+    })
+
+    it('includes one Review per testimonial with matching author and rating', () => {
+      const schema = organizationSchema()
+      expect(schema.review).toHaveLength(TESTIMONIALS.length)
+      expect(schema.review[0]).toMatchObject({
+        '@type': 'Review',
+        author: { '@type': 'Person', name: TESTIMONIALS[0].author },
+        reviewBody: TESTIMONIALS[0].quote,
+        reviewRating: {
+          '@type': 'Rating',
+          ratingValue: TESTIMONIALS[0].rating,
+        },
+      })
     })
   })
 

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,5 +1,5 @@
 import { IMG_WIDTH_ICON, IMG_WIDTH_OG, imgUrl } from './cloudinary'
-import { CONTACT } from './data'
+import { CONTACT, TESTIMONIALS } from './data'
 
 const BASE_URL = 'https://roadmapcol.com'
 const LOGO_URL = imgUrl(
@@ -8,9 +8,19 @@ const LOGO_URL = imgUrl(
 )
 
 export function organizationSchema() {
+  const ratingValue =
+    TESTIMONIALS.reduce((sum, testimonial) => sum + testimonial.rating, 0) /
+    TESTIMONIALS.length
+
   return {
     '@context': 'https://schema.org',
     '@type': 'Organization',
+    aggregateRating: {
+      '@type': 'AggregateRating',
+      bestRating: 5,
+      ratingValue: Number(ratingValue.toFixed(1)),
+      reviewCount: TESTIMONIALS.length,
+    },
     contactPoint: {
       '@type': 'ContactPoint',
       contactType: 'customer support',
@@ -19,6 +29,16 @@ export function organizationSchema() {
     },
     logo: LOGO_URL,
     name: 'Road Map Col',
+    review: TESTIMONIALS.map((testimonial) => ({
+      '@type': 'Review',
+      author: { '@type': 'Person', name: testimonial.author },
+      reviewBody: testimonial.quote,
+      reviewRating: {
+        '@type': 'Rating',
+        bestRating: 5,
+        ratingValue: testimonial.rating,
+      },
+    })),
     sameAs: [CONTACT.instagram, CONTACT.tiktok],
     url: BASE_URL,
   }


### PR DESCRIPTION
## What and why
Audited the whole project for how well it leverages Next.js SSR/App Router,
and for SEO gaps. The good news: `generateStaticParams`, `generateMetadata`
(canonical + OG/Twitter), and per-page JSON-LD were already correctly wired
on every route (home, `/tours`, tour detail, `/blog`, blog post, `/personalize`).

The real gap: `'use client'` boundaries were drawn too wide on the two
content-heavy pages, turning static/SEO-relevant text (tour descriptions,
highlights, activity details) into client-shipped JS for the sake of one
small piece of interactive state. There was also no review/rating
structured data anywhere despite `TESTIMONIALS` already having ratings.

## Changes
- **Tour detail page** (`tour-client.tsx`): now a **Server Component**. Extracted the interactive slice into three small client islands:
  - `tour-booking-context.tsx` — `TourBookingProvider`/`useTourBooking`, owns `selectedActivities` state
  - `activity-toggle-button.tsx` — the per-activity "Add/Remove" button
  - `booking-summary.tsx` — the price summary + WhatsApp CTA (needs the live total)

  Everything else (gallery, description, highlights, activity cards, images) is server-rendered with zero client JS.
- **Personalize page**: `page.tsx` now server-renders the static title/intro copy; `personalize-client.tsx` keeps only the form (legitimately interactive end-to-end, not touched further).
- **SEO**: added `aggregateRating` + a `review` array to `organizationSchema()` (site-wide JSON-LD in the root layout), computed from `TESTIMONIALS` — makes the site eligible for star-rating rich snippets in search results.

## Type of change
- [x] Performance improvement (non-breaking)
- [x] SEO improvement (non-breaking)

## Test plan
- [x] `bun run lint` — clean (2 pre-existing warnings unrelated to this branch)
- [x] `bun run type-check` — no errors
- [x] `bunx vitest run --coverage` — 225/225 tests passing, 100% coverage (added tests for the new context, its outside-provider guard, and the new review/rating schema)
- [x] `bun run build && bun run start`, then `curl`: confirmed all tour-detail static content **and** the "Add to my experience" buttons are present in the raw SSR HTML (no JS required to see them), and `aggregateRating`/`review` appear in the JSON-LD on every page
- [x] Headless browser check: clicking "Add to my experience" still correctly shows "Remove from my experience", "Selected activities:", and "Total:" — the split didn't break interactivity
- [x] Visual regression screenshots on home, `/tours`, a tour detail page, and `/blog` — no visible regressions

## Notes for reviewer
- Found but **not fixed** here (flagged separately, unrelated scope): `TourGallery`/`MediaCarousel` (`src/components/tour-gallery.tsx`, `src/components/ui/carousel.tsx`) appear to be dead code — no callers anywhere except their own tests. `TourMediaCarousel` (a different, actually-used component) replaced them at some point. Worth a cleanup issue.
- Didn't attempt a similar split on `header.tsx`/carousels/Radix-based UI primitives — those are legitimately interactive (scroll listener, embla state, menu state) with no meaningful static content to hoist out.