### PR TITLE
fix: add sizes attribute to blog images (#42)

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -55,6 +55,7 @@ export default async function BlogPostPage({ params }: PageProps) {
           alt={post.title}
           fill
           priority
+          sizes="(max-width: 768px) 100vw, 768px"
           className="object-cover"
         />
       </div>

--- a/src/app/blog/__tests__/blog-index.test.tsx
+++ b/src/app/blog/__tests__/blog-index.test.tsx
@@ -2,8 +2,8 @@ import BlogIndex from '@/app/blog/page'
 import { render, screen } from '@testing-library/react'
 
 vi.mock('next/image', () => ({
-  default: (props: { alt: string; src: string }) => (
-    <img alt={props.alt} src={props.src} />
+  default: (props: { alt: string; sizes?: string; src: string }) => (
+    <img alt={props.alt} src={props.src} sizes={props.sizes} />
   ),
 }))
 
@@ -50,5 +50,16 @@ describe('Blog index page', () => {
     render(<BlogIndex />)
     expect(screen.getByText('Description A')).toBeInTheDocument()
     expect(screen.getByText('3 min read')).toBeInTheDocument()
+  })
+
+  it('declares an accurate sizes attribute so the browser picks a small source', () => {
+    render(<BlogIndex />)
+    const images = document.querySelectorAll('img')
+    images.forEach((img) => {
+      expect(img).toHaveAttribute(
+        'sizes',
+        '(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw'
+      )
+    })
   })
 })

--- a/src/app/blog/__tests__/blog-post.test.tsx
+++ b/src/app/blog/__tests__/blog-post.test.tsx
@@ -5,6 +5,12 @@ import BlogPostPage, {
 import { render, screen } from '@testing-library/react'
 import { notFound } from 'next/navigation'
 
+vi.mock('next/image', () => ({
+  default: (props: { alt: string; sizes?: string; src: string }) => (
+    <img alt={props.alt} src={props.src} sizes={props.sizes} />
+  ),
+}))
+
 vi.mock('next/navigation', () => ({
   notFound: vi.fn(() => {
     throw new Error('NEXT_NOT_FOUND')
@@ -102,6 +108,17 @@ describe('BlogPostPage', () => {
     expect(screen.getByText('See our tours').closest('a')).toHaveAttribute(
       'href',
       '/tours'
+    )
+  })
+
+  it('declares an accurate sizes attribute on the cover image', async () => {
+    const element = await BlogPostPage({
+      params: Promise.resolve({ slug: 'post-a' }),
+    })
+    render(element)
+    expect(screen.getByAltText('Post A')).toHaveAttribute(
+      'sizes',
+      '(max-width: 768px) 100vw, 768px'
     )
   })
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -52,6 +52,7 @@ export default function BlogIndex() {
                 src={imgUrl(post.coverImage, IMG_WIDTH_CARD)}
                 alt={post.title}
                 fill
+                sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
                 className="object-cover transition-transform duration-300 group-hover:scale-105"
               />
             </div>


### PR DESCRIPTION
## What and why
Both blog `<Image fill>` components were missing a `sizes` attribute, so
`next/image` fell back to `sizes="100vw"`:
- `src/app/blog/page.tsx` — index cards render at ~387px on desktop (3-col grid inside `max-w-7xl`) but the browser was picking a full-viewport-width source (e.g. ~1920w) — 3–5x more bytes than needed, × every post.
- `src/app/blog/[slug]/page.tsx` — cover renders inside `max-w-3xl` (~704–768px) but downloaded a 100vw source; it also uses `priority`, so the oversized fetch was render-blocking too.

## Changes
- Index cards: `sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"`
- Post cover: `sizes="(max-width: 768px) 100vw, 768px"`
- Updated both blog test files' local `next/image` mocks to forward `sizes`, and added a test per page asserting the attribute

## Type of change
- [x] Performance improvement (non-breaking)

## Test plan
- [x] `bun run lint` — clean (3 pre-existing/expected warnings, none new errors)
- [x] `bun run type-check` — no errors
- [x] `bunx vitest run --coverage` — 227/227 tests passing, 100% coverage
- [x] `bun run build && bun run start`, then a headless check at a 1440px viewport:
  - Index cards (rendered ~387px wide) now select `w_640` from the srcset — previously would've selected the ~1920w candidate. Well under the 828w threshold from the issue's DoD.
  - Post cover (rendered ~704px wide) selects `w_828`.
- [x] Visual regression screenshot on a blog post page — no visible regression

---
Closes #42